### PR TITLE
[정봉찬] Week4

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -1,2 +1,2 @@
-@import './common.css';
 @import './reset.css';
+@import './common.css';

--- a/css/sign.css
+++ b/css/sign.css
@@ -115,6 +115,7 @@ body {
   top: 0;
   bottom: 0;
   margin: auto 0.94rem;
+  cursor: pointer;
 }
 
 .input-container input {

--- a/css/sign.css
+++ b/css/sign.css
@@ -98,6 +98,12 @@ body {
   line-height: normal;
 }
 
+.input-box {
+  display: flex;
+  flex-direction: column;
+  gap: 0.38rem;
+}
+
 .input-background {
   position: relative;
 }
@@ -129,6 +135,23 @@ body {
 .input-container input:valid,
 .input-container input:invalid {
   background-color: var(--Linkbrary-white);
+}
+
+.input-container input.error {
+  outline: 0.06rem solid var(--Linkbrary-red);
+}
+
+.input-message {
+  display: none;
+  font-size: 0.88rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.input-message.error {
+  display: block;
+  color: var(--Linkbrary-red);
 }
 
 form .btn-link {

--- a/css/sign.css
+++ b/css/sign.css
@@ -134,6 +134,8 @@ body {
 form .btn-link {
   font-size: 1.13rem;
   padding: 1.25rem 1rem;
+  width: 100%;
+  border: none;
 }
 
 .footer {

--- a/faq/index.html
+++ b/faq/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/folder/index.html
+++ b/folder/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <h1>folder</h1>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/js/sign.js
+++ b/js/sign.js
@@ -1,23 +1,48 @@
-const inputEmail = document.querySelector('#email');
+const INPUT_TYPE = {
+  EMAIL: 'EMAIL',
+  PASSWORD: 'PASSWORD',
+};
 
-function handleEmailInput(event) {
+const INPUT_MESSAGE_EMPTY = {
+  [INPUT_TYPE.EMAIL]: '이메일을 입력해 주세요.',
+  [INPUT_TYPE.PASSWORD]: '비밀번호를 입력해 주세요.',
+};
+
+const INPUT_MESSAGE_PATTERN_ERROR = {
+  [INPUT_TYPE.EMAIL]: '올바른 이메일 주소가 아닙니다.',
+};
+
+const ERROR_CLASS = 'error';
+
+const inputWrapper = document.querySelector('.inputs');
+
+function handleFocusoutInput(event) {
   const target = event.target;
-  const email = target.value;
+
+  if (target.tagName.toUpperCase() !== 'INPUT') return;
+  const value = target.value;
+  const type = target.dataset.type.toUpperCase();
   const messageBox = target.parentElement.nextElementSibling;
-  target.classList.remove('error');
-  messageBox.classList.remove('error');
-  if (!email) {
-    target.classList.add('error');
-    return printMessage(messageBox, '이메일을 입력해 주세요.', 'error');
+  let message = '';
+  target.classList.remove(ERROR_CLASS);
+  messageBox.classList.remove(ERROR_CLASS);
+
+  if (!value) {
+    target.classList.add(ERROR_CLASS);
+    message = INPUT_MESSAGE_EMPTY[type];
+    return printMessage(messageBox, message, ERROR_CLASS);
   }
 
-  const valid = validateEmail(email);
+  let valid = true;
+  if (type === INPUT_TYPE.EMAIL) {
+    valid = validateEmail(value);
+  }
+
   if (!valid) {
-    target.classList.add('error');
-    return printMessage(messageBox, '올바른 이메일 주소가 아닙니다.', 'error');
+    target.classList.add(ERROR_CLASS);
+    message = INPUT_MESSAGE_PATTERN_ERROR[type];
+    return printMessage(messageBox, message, ERROR_CLASS);
   }
-
-  console.log(email);
 }
 
 function validateEmail(email) {
@@ -34,4 +59,4 @@ function printMessage(target, message, className) {
   target.classList.add(className);
 }
 
-inputEmail.addEventListener('focusout', handleEmailInput);
+inputWrapper.addEventListener('focusout', handleFocusoutInput);

--- a/js/sign.js
+++ b/js/sign.js
@@ -12,18 +12,30 @@ const INPUT_MESSAGE_PATTERN_ERROR = {
   [INPUT_TYPE.EMAIL]: '올바른 이메일 주소가 아닙니다.',
 };
 
+const INPUT_MESSAGE_LOGIN_ERROR = {
+  [INPUT_TYPE.EMAIL]: '이메일을 확인해 주세요.',
+  [INPUT_TYPE.PASSWORD]: '비밀번호를 확인해 주세요.',
+};
+
 const ERROR_CLASS = 'error';
 
-const inputWrapper = document.querySelector('.inputs');
+const USER_TEST = {
+  [INPUT_TYPE.EMAIL]: 'test@codeit.com',
+  [INPUT_TYPE.PASSWORD]: 'codeit101',
+};
+
+const signForm = document.querySelector('#signForm');
 
 function handleFocusoutInput(event) {
   const target = event.target;
 
   if (target.tagName.toUpperCase() !== 'INPUT') return;
+
   const value = target.value;
   const type = target.dataset.type.toUpperCase();
   const messageBox = target.parentElement.nextElementSibling;
   let message = '';
+
   target.classList.remove(ERROR_CLASS);
   messageBox.classList.remove(ERROR_CLASS);
 
@@ -45,6 +57,42 @@ function handleFocusoutInput(event) {
   }
 }
 
+function handleSubmit(event) {
+  event.preventDefault();
+
+  if (event.target.id !== 'signForm') return;
+
+  let valid = true;
+  const emailInput = event.target['email'];
+  const passwordInput = event.target['password'];
+  const emailMessageBox = emailInput.parentElement.nextElementSibling;
+  const passwordMessageBox = passwordInput.parentElement.nextElementSibling;
+
+  emailInput.classList.remove(ERROR_CLASS);
+  passwordInput.classList.remove(ERROR_CLASS);
+  emailMessageBox.classList.remove(ERROR_CLASS);
+  passwordMessageBox.classList.remove(ERROR_CLASS);
+
+  if (USER_TEST.EMAIL !== emailInput.value) {
+    valid = false;
+    emailInput.classList.add(ERROR_CLASS);
+    printMessage(emailMessageBox, INPUT_MESSAGE_LOGIN_ERROR.EMAIL, ERROR_CLASS);
+  } else if (USER_TEST.PASSWORD !== passwordInput.value) {
+    valid = false;
+    passwordInput.classList.add(ERROR_CLASS);
+    printMessage(
+      passwordMessageBox,
+      INPUT_MESSAGE_LOGIN_ERROR.PASSWORD,
+      ERROR_CLASS
+    );
+  }
+
+  if (!valid) return;
+
+  // event.target.submit();
+  window.location.href = '/folder';
+}
+
 function validateEmail(email) {
   const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
   if (emailRegex.test(email)) {
@@ -59,4 +107,5 @@ function printMessage(target, message, className) {
   target.classList.add(className);
 }
 
-inputWrapper.addEventListener('focusout', handleFocusoutInput);
+signForm.addEventListener('focusout', handleFocusoutInput);
+signForm.addEventListener('submit', handleSubmit);

--- a/js/sign.js
+++ b/js/sign.js
@@ -17,6 +17,26 @@ const INPUT_MESSAGE_LOGIN_ERROR = {
   [INPUT_TYPE.PASSWORD]: '비밀번호를 확인해 주세요.',
 };
 
+const BLIND_TYPE = {
+  ON: 'on',
+  OFF: 'off',
+};
+
+const BLIND_IMAGE_SRC = {
+  [BLIND_TYPE.ON]: '/images/sign/eye_off.svg',
+  [BLIND_TYPE.OFF]: '/images/sign/eye_on.svg',
+};
+
+const BLIND_IMAGE_ALT = {
+  [BLIND_TYPE.ON]: '비밀번호 숨기기 이미지',
+  [BLIND_TYPE.OFF]: '비밀번호 보이기 이미지',
+};
+
+const BLIND_INPUT_TYPE = {
+  [BLIND_TYPE.ON]: 'password',
+  [BLIND_TYPE.OFF]: 'text',
+};
+
 const ERROR_CLASS = 'error';
 
 const USER_TEST = {
@@ -60,7 +80,7 @@ function handleFocusoutInput(event) {
 function handleSubmit(event) {
   event.preventDefault();
 
-  if (event.target.id !== 'signForm') return;
+  if (event.target.id.toUpperCase() !== 'SIGNFORM') return;
 
   let valid = true;
   const emailInput = event.target['email'];
@@ -107,5 +127,23 @@ function printMessage(target, message, className) {
   target.classList.add(className);
 }
 
+function handleClickBlindButton(event) {
+  event.stopPropagation();
+  const target = event.target;
+
+  if (!target.classList.contains('input-blind-toggle')) return;
+
+  const input = target.previousElementSibling;
+  let blindType = target.dataset.type.toLowerCase();
+
+  blindType = blindType === BLIND_TYPE.ON ? BLIND_TYPE.OFF : BLIND_TYPE.ON;
+
+  input.setAttribute('type', BLIND_INPUT_TYPE[blindType]);
+  target.setAttribute('src', BLIND_IMAGE_SRC[blindType]);
+  target.setAttribute('alt', BLIND_IMAGE_ALT[blindType]);
+  target.setAttribute('data-type', blindType);
+}
+
 signForm.addEventListener('focusout', handleFocusoutInput);
 signForm.addEventListener('submit', handleSubmit);
+signForm.addEventListener('click', handleClickBlindButton);

--- a/js/sign.js
+++ b/js/sign.js
@@ -1,0 +1,37 @@
+const inputEmail = document.querySelector('#email');
+
+function handleEmailInput(event) {
+  const target = event.target;
+  const email = target.value;
+  const messageBox = target.parentElement.nextElementSibling;
+  target.classList.remove('error');
+  messageBox.classList.remove('error');
+  if (!email) {
+    target.classList.add('error');
+    return printMessage(messageBox, '이메일을 입력해 주세요.', 'error');
+  }
+
+  const valid = validateEmail(email);
+  if (!valid) {
+    target.classList.add('error');
+    return printMessage(messageBox, '올바른 이메일 주소가 아닙니다.', 'error');
+  }
+
+  console.log(email);
+}
+
+function validateEmail(email) {
+  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  if (emailRegex.test(email)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function printMessage(target, message, className) {
+  target.innerHTML = message;
+  target.classList.add(className);
+}
+
+inputEmail.addEventListener('focusout', handleEmailInput);

--- a/js/sign.js
+++ b/js/sign.js
@@ -58,6 +58,7 @@ function handleFocusoutInput(event) {
 
   target.classList.remove(ERROR_CLASS);
   messageBox.classList.remove(ERROR_CLASS);
+  messageBox.textContent = '';
 
   if (!value) {
     target.classList.add(ERROR_CLASS);
@@ -91,7 +92,9 @@ function handleSubmit(event) {
   emailInput.classList.remove(ERROR_CLASS);
   passwordInput.classList.remove(ERROR_CLASS);
   emailMessageBox.classList.remove(ERROR_CLASS);
+  emailMessageBox.textContent = '';
   passwordMessageBox.classList.remove(ERROR_CLASS);
+  passwordMessageBox.textContent = '';
 
   if (USER_TEST.EMAIL !== emailInput.value) {
     valid = false;

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/signin/index.html
+++ b/signin/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/signin/index.html
+++ b/signin/index.html
@@ -32,18 +32,24 @@
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>
-              <div class="input-background">
-                <input type="email" name="email" id="email" />
+              <div class="input-box">
+                <div class="input-background">
+                  <input type="email" name="email" id="email" />
+                </div>
+                <div class="input-message"></div>
               </div>
             </div>
             <div class="input-container">
               <label for="password">비밀번호</label>
-              <div class="input-background">
-                <input type="password" name="password" id="password" />
-                <img
-                  src="/images/sign/eye_off.svg"
-                  alt="비밀번호 숨기기 이미지"
-                />
+              <div class="input-box">
+                <div class="input-background">
+                  <input type="password" name="password" id="password" />
+                  <img
+                    src="/images/sign/eye_off.svg"
+                    alt="비밀번호 숨기기 이미지"
+                  />
+                </div>
+                <div class="input-message"></div>
               </div>
             </div>
           </div>
@@ -65,5 +71,6 @@
         </div>
       </div>
     </div>
+    <script src="/js/sign.js"></script>
   </body>
 </html>

--- a/signin/index.html
+++ b/signin/index.html
@@ -28,7 +28,7 @@
             </div>
           </div>
         </div>
-        <form action="/folder" method="post">
+        <form id="signForm" action="/folder" method="post">
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>
@@ -48,12 +48,7 @@
               <label for="password">비밀번호</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input
-                    type="password"
-                    name="password"
-                    id="password"
-                    data-type="password"
-                  />
+                  <input type="password" name="password" data-type="password" />
                   <img
                     src="/images/sign/eye_off.svg"
                     alt="비밀번호 숨기기 이미지"
@@ -81,6 +76,6 @@
         </div>
       </div>
     </div>
-    <script src="/js/sign.js" type="module"></script>
+    <script src="/js/sign.js"></script>
   </body>
 </html>

--- a/signin/index.html
+++ b/signin/index.html
@@ -51,6 +51,8 @@
                   <input type="password" name="password" data-type="password" />
                   <img
                     src="/images/sign/eye_off.svg"
+                    class="input-blind-toggle"
+                    data-type="on"
                     alt="비밀번호 숨기기 이미지"
                   />
                 </div>

--- a/signin/index.html
+++ b/signin/index.html
@@ -39,6 +39,7 @@
                     name="email"
                     id="email"
                     data-type="email"
+                    required
                   />
                 </div>
                 <div class="input-message"></div>
@@ -48,7 +49,12 @@
               <label for="password">비밀번호</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input type="password" name="password" data-type="password" />
+                  <input
+                    type="password"
+                    name="password"
+                    data-type="password"
+                    required
+                  />
                   <img
                     src="/images/sign/eye_off.svg"
                     class="input-blind-toggle"

--- a/signin/index.html
+++ b/signin/index.html
@@ -28,7 +28,7 @@
             </div>
           </div>
         </div>
-        <form action="">
+        <form action="/folder" method="post">
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>
@@ -47,7 +47,7 @@
               </div>
             </div>
           </div>
-          <a href="" class="btn-link">로그인</a>
+          <button type="submit" class="btn-link">로그인</button>
         </form>
       </div>
       <div class="footer">

--- a/signin/index.html
+++ b/signin/index.html
@@ -34,7 +34,12 @@
               <label for="email">이메일</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input type="email" name="email" id="email" />
+                  <input
+                    type="email"
+                    name="email"
+                    id="email"
+                    data-type="email"
+                  />
                 </div>
                 <div class="input-message"></div>
               </div>
@@ -43,7 +48,12 @@
               <label for="password">비밀번호</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input type="password" name="password" id="password" />
+                  <input
+                    type="password"
+                    name="password"
+                    id="password"
+                    data-type="password"
+                  />
                   <img
                     src="/images/sign/eye_off.svg"
                     alt="비밀번호 숨기기 이미지"
@@ -71,6 +81,6 @@
         </div>
       </div>
     </div>
-    <script src="/js/sign.js"></script>
+    <script src="/js/sign.js" type="module"></script>
   </body>
 </html>

--- a/signup/index.html
+++ b/signup/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/signup/index.html
+++ b/signup/index.html
@@ -28,7 +28,7 @@
             </div>
           </div>
         </div>
-        <form action="/folder" method="post">
+        <form id="signForm" action="/folder" method="post">
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>

--- a/signup/index.html
+++ b/signup/index.html
@@ -32,32 +32,42 @@
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>
-              <div class="input-background">
-                <input type="email" name="email" id="email" />
+              <div class="input-box">
+                <div class="input-background">
+                  <input type="email" name="email" id="email" />
+                  <div class="input-message"></div>
+                </div>
+                <div class="input-message">내용을 다시 작성해주세요</div>
               </div>
             </div>
             <div class="input-container">
               <label for="password">비밀번호</label>
-              <div class="input-background">
-                <input type="text" name="password" id="password" />
-                <img
-                  src="/images/sign/eye_on.svg"
-                  alt="비밀번호 보이기 이미지"
-                />
+              <div class="input-box">
+                <div class="input-background">
+                  <input type="text" name="password" id="password" />
+                  <img
+                    src="/images/sign/eye_on.svg"
+                    alt="비밀번호 보이기 이미지"
+                  />
+                </div>
+                <div class="input-message"></div>
               </div>
             </div>
             <div class="input-container">
               <label for="password-repeat">비밀번호 확인</label>
-              <div class="input-background">
-                <input
-                  type="text"
-                  name="password-repeat"
-                  id="password-repeat"
-                />
-                <img
-                  src="/images/sign/eye_on.svg"
-                  alt="비밀번호 보이기 이미지"
-                />
+              <div class="input-box">
+                <div class="input-background">
+                  <input
+                    type="text"
+                    name="password-repeat"
+                    id="password-repeat"
+                  />
+                  <img
+                    src="/images/sign/eye_on.svg"
+                    alt="비밀번호 보이기 이미지"
+                  />
+                </div>
+                <div class="input-message"></div>
               </div>
             </div>
           </div>
@@ -79,5 +89,6 @@
         </div>
       </div>
     </div>
+    <script src="/js/sign.js"></script>
   </body>
 </html>

--- a/signup/index.html
+++ b/signup/index.html
@@ -39,6 +39,7 @@
                     name="email"
                     id="email"
                     data-type="email"
+                    required
                   />
                   <div class="input-message"></div>
                 </div>
@@ -54,6 +55,7 @@
                     name="password"
                     id="password"
                     data-type="password"
+                    required
                   />
                   <img
                     src="/images/sign/eye_on.svg"
@@ -72,6 +74,7 @@
                     name="password-repeat"
                     id="password-repeat"
                     data-type="password"
+                    required
                   />
                   <img
                     src="/images/sign/eye_on.svg"

--- a/signup/index.html
+++ b/signup/index.html
@@ -34,7 +34,12 @@
               <label for="email">이메일</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input type="email" name="email" id="email" />
+                  <input
+                    type="email"
+                    name="email"
+                    id="email"
+                    data-type="email"
+                  />
                   <div class="input-message"></div>
                 </div>
                 <div class="input-message">내용을 다시 작성해주세요</div>
@@ -44,7 +49,12 @@
               <label for="password">비밀번호</label>
               <div class="input-box">
                 <div class="input-background">
-                  <input type="text" name="password" id="password" />
+                  <input
+                    type="text"
+                    name="password"
+                    id="password"
+                    data-type="password"
+                  />
                   <img
                     src="/images/sign/eye_on.svg"
                     alt="비밀번호 보이기 이미지"
@@ -61,6 +71,7 @@
                     type="text"
                     name="password-repeat"
                     id="password-repeat"
+                    data-type="password"
                   />
                   <img
                     src="/images/sign/eye_on.svg"

--- a/signup/index.html
+++ b/signup/index.html
@@ -28,7 +28,7 @@
             </div>
           </div>
         </div>
-        <form action="">
+        <form action="/folder" method="post">
           <div class="inputs">
             <div class="input-container">
               <label for="email">이메일</label>
@@ -61,7 +61,7 @@
               </div>
             </div>
           </div>
-          <a href="" class="btn-link">회원가입</a>
+          <button type="submit" class="btn-link">회원가입</button>
         </form>
       </div>
       <div class="footer">


### PR DESCRIPTION
## 요구사항

### 💧기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?

- [x] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?

- [x] 이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] 이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

- [x] 로그인 버튼 클릭 또는 Enter키 입력으로 로그인 되나요?

### 🔥심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?

- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

## 주요 변경사항

- [피드백] 모든 html의 `lang="en"`을 `lang="ko"`로 변경.
- [피드백] `global.css`의 `common.css`와 `reset.css`의 import 위치 변경.
- [피드백] `input` 태그에 `required` 속성 추가.
- 로그인 페이지의 `input` 유효성 검사.
- 로그인 페이지의 로그인 기능. [테스트 유저] email: test@codeit.com, password: codeit101
- 로그인 페이지의 눈 모양 아이콘 클릭 시 비밀번호 노출 토글.

## 배포 사이트

[linkbrary](https://devwqc-linkbrary.netlify.app/signin/)

## 멘토에게

- 로그인, 회원가입에서 공통적으로 쓰는 상수, 함수들을 따로 js로 빼서 모듈화 하고 싶었지만 이번 주차 과제는 로그인 페이지에 한정되어 있어서 회원가입 기능을 구현할 때 리팩토링 하면서 따로 빼려고 생각 중입니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
