### PR TITLE
[이서인] Week4

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,5 @@
         <img src="./source/ant-design_instagram-filled.svg" alt="인스타그램 로고" />
       </div>
     </footer>
-    <script src="signin.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -106,5 +106,6 @@
         <img src="./source/ant-design_instagram-filled.svg" alt="인스타그램 로고" />
       </div>
     </footer>
+    <script src="signin.js"></script>
   </body>
 </html>

--- a/signin.css
+++ b/signin.css
@@ -156,3 +156,15 @@ button {
     margin-right: 32px;
   }
 }
+
+.invalid {
+  border-color: red;
+}
+
+#emailError {
+  color: red;
+}
+
+#passwordError {
+  color: red;
+}

--- a/signin.css
+++ b/signin.css
@@ -158,13 +158,21 @@ button {
 }
 
 .invalid {
-  border-color: red;
+  border: 1px solid #ff5b56;
 }
 
 #emailError {
-  color: red;
+  font-family: Pretendard;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16.8px;
+  color: #ff5b56;
 }
 
 #passwordError {
-  color: red;
+  font-family: Pretendard;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16.8px;
+  color: #ff5b56;
 }

--- a/signin.html
+++ b/signin.html
@@ -37,5 +37,6 @@
         </div>
       </section>
     </main>
+    <script src="signin.js"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -29,7 +29,7 @@
         </div>
       </section>
       <section class="bottom">
-        <button>로그인</button>
+        <button id="loginBtn">로그인</button>
         <div class="socialLogin">
           <p>소셜 로그인</p>
           <div class="sns">

--- a/signin.html
+++ b/signin.html
@@ -19,11 +19,11 @@
       <section class="middle">
         <div class="input">
           <p>이메일</p>
-          <input type="email" placeholder="codeit@codeit.com" />
+          <input id="email" type="email" placeholder="codeit@codeit.com" />
         </div>
         <div class="input">
           <p>비밀번호</p>
-          <input type="password" placeholder="········" />
+          <input id="password" type="password" placeholder="········" />
         </div>
       </section>
       <section class="bottom">

--- a/signin.html
+++ b/signin.html
@@ -20,10 +20,12 @@
         <div class="input">
           <p>이메일</p>
           <input id="email" type="email" placeholder="codeit@codeit.com" />
+          <span id="emailError"></span>
         </div>
         <div class="input">
           <p>비밀번호</p>
           <input id="password" type="password" placeholder="········" />
+          <span id="passwordError"></span>
         </div>
       </section>
       <section class="bottom">

--- a/signin.html
+++ b/signin.html
@@ -29,7 +29,7 @@
         </div>
       </section>
       <section class="bottom">
-        <button id="loginBtn">로그인</button>
+        <button id="loginButton">로그인</button>
         <div class="socialLogin">
           <p>소셜 로그인</p>
           <div class="sns">

--- a/signin.html
+++ b/signin.html
@@ -16,7 +16,7 @@
         </div>
         <p class="question">회원이 아니신가요? <a href="/signup">회원 가입하기</a></p>
       </section>
-      <section class="middle">
+      <form class="middle">
         <div class="input">
           <p>이메일</p>
           <input id="email" type="email" placeholder="codeit@codeit.com" />
@@ -27,7 +27,7 @@
           <input id="password" type="password" placeholder="········" />
           <span id="passwordError"></span>
         </div>
-      </section>
+      </form>
       <section class="bottom">
         <button id="loginButton">로그인</button>
         <div class="socialLogin">

--- a/signin.js
+++ b/signin.js
@@ -43,3 +43,11 @@ function login() {
     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
   }
 }
+
+//로그인 버튼에 이벤트 리스너 등록
+document.querySelector('#loginBtn').addEventListener('click', login);
+document.querySelector('#loginBtn').addEventListener('keydown', function (e) {
+  if (e.keyCode === 13) {
+    login();
+  }
+});

--- a/signin.js
+++ b/signin.js
@@ -1,11 +1,12 @@
 const emailInput = document.querySelector('#email');
+const emailPattern = /^A[0-9a-zA-Z] ([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
 const emailError = document.querySelector('#emailError');
 const passwordInput = document.querySelector('#password');
 const passwordError = document.querySelector('#passwordError');
 
 //email 에러 메시지 호출
 emailInput.addEventListener('focusout', function () {
-  if (!emailInput.value.includes('@')) {
+  if (!emailPattern.test(emailInput.value)) {
     emailInput.classList.add('invalid');
     emailError.innerHTML = emailInput.value.trim() ? '올바른 이메일 주소가 아닙니다.' : '이메일을 입력해 주세요.';
   } else {

--- a/signin.js
+++ b/signin.js
@@ -1,0 +1,26 @@
+const emailForm = document.querySelector('#email');
+const emailError = document.querySelector('#emailError');
+const passwordForm = document.querySelector('#password');
+const passwordError = document.querySelector('#passwordError');
+
+//email 에러 메시지 호출
+emailForm.addEventListener('focusout', function () {
+  if (!emailForm.value.includes('@')) {
+    emailForm.classList.add('invalid');
+    emailError.innerHTML = emailForm.value.trim() ? '올바른 이메일 주소가 아닙니다.' : '이메일을 입력해 주세요.';
+  } else {
+    emailForm.classList.remove('invalid');
+    emailError.innerHTML = '';
+  }
+});
+
+//password 에러 메시지 호출
+passwordForm.addEventListener('focusout', function () {
+  if (!passwordForm.value.trim()) {
+    passwordForm.classList.add('invalid');
+    passwordError.innerHTML = '비밀번호를 입력해 주세요.';
+  } else {
+    passwordForm.classList.remove('invalid');
+    passwordError.innerHTML = '';
+  }
+});

--- a/signin.js
+++ b/signin.js
@@ -3,6 +3,7 @@ const emailPattern = new RegExp('[a-z0-9]+@[a-z]+.[a-z]{2,3}');
 const emailError = document.querySelector('#emailError');
 const passwordInput = document.querySelector('#password');
 const passwordError = document.querySelector('#passwordError');
+const loginButton = document.querySelector('#loginButton');
 
 //email 에러 메시지 호출
 emailInput.addEventListener('focusout', function () {
@@ -51,9 +52,12 @@ function login() {
 }
 
 //로그인 버튼에 이벤트 리스너 등록
-document.querySelector('#loginButton').addEventListener('click', login);
-document.querySelector('#loginButton').addEventListener('keydown', function (e) {
-  if (e.keyCode === 13) {
+loginButton.addEventListener('click', login);
+
+function loginButtonByEnter(e) {
+  if (e.key === 'Enter') {
     login();
+    e.preventDefault();
   }
-});
+}
+loginButton.addEventListener('keypress', loginButtonByEnter);

--- a/signin.js
+++ b/signin.js
@@ -24,3 +24,22 @@ passwordForm.addEventListener('focusout', function () {
     passwordError.innerHTML = '';
   }
 });
+
+//특정 이메일과 비밀번호 입력 시 페이지 이동
+const validEmail = 'test@codeit.com';
+const validPassword = 'codeit101';
+
+function login() {
+  const emailValue = document.querySelector('#email').value;
+  const passwordValue = document.querySelector('#password').value;
+
+  if (emailValue === validEmail && passwordValue === validPassword) {
+    window.location.href = './folder';
+  } else if (emailValue !== validEmail) {
+    emailForm.classList.add('invalid');
+    emailError.innerHTML = '이메일을 확인해 주세요.';
+  } else if (passwordValue !== validPassword) {
+    passwordForm.classList.add('invalid');
+    passwordError.innerHTML = '비밀번호를 확인해 주세요.';
+  }
+}

--- a/signin.js
+++ b/signin.js
@@ -51,8 +51,8 @@ function login() {
 }
 
 //로그인 버튼에 이벤트 리스너 등록
-document.querySelector('#loginBtn').addEventListener('click', login);
-document.querySelector('#loginBtn').addEventListener('keydown', function (e) {
+document.querySelector('#loginButton').addEventListener('click', login);
+document.querySelector('#loginButton').addEventListener('keydown', function (e) {
   if (e.keyCode === 13) {
     login();
   }

--- a/signin.js
+++ b/signin.js
@@ -31,8 +31,8 @@ const validEmail = 'test@codeit.com';
 const validPassword = 'codeit101';
 
 function login() {
-  const emailValue = document.querySelector('#email').value;
-  const passwordValue = document.querySelector('#password').value;
+  const emailValue = emailInput.value;
+  const passwordValue = passwordInput.value;
 
   if (emailValue === validEmail && passwordValue === validPassword) {
     window.location.href = './folder';

--- a/signin.js
+++ b/signin.js
@@ -1,5 +1,5 @@
 const emailInput = document.querySelector('#email');
-const emailPattern = /^A[0-9a-zA-Z] ([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/;
+const emailPattern = new RegExp('[a-z0-9]+@[a-z]+.[a-z]{2,3}');
 const emailError = document.querySelector('#emailError');
 const passwordInput = document.querySelector('#password');
 const passwordError = document.querySelector('#passwordError');
@@ -36,10 +36,15 @@ function login() {
 
   if (emailValue === validEmail && passwordValue === validPassword) {
     window.location.href = './folder';
-  } else if (emailValue !== validEmail) {
+    return;
+  }
+
+  if (emailValue !== validEmail) {
     emailInput.classList.add('invalid');
     emailError.innerHTML = '이메일을 확인해 주세요.';
-  } else if (passwordValue !== validPassword) {
+  }
+
+  if (passwordValue !== validPassword) {
     passwordInput.classList.add('invalid');
     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
   }

--- a/signin.js
+++ b/signin.js
@@ -1,26 +1,26 @@
-const emailForm = document.querySelector('#email');
+const emailInput = document.querySelector('#email');
 const emailError = document.querySelector('#emailError');
-const passwordForm = document.querySelector('#password');
+const passwordInput = document.querySelector('#password');
 const passwordError = document.querySelector('#passwordError');
 
 //email 에러 메시지 호출
-emailForm.addEventListener('focusout', function () {
-  if (!emailForm.value.includes('@')) {
-    emailForm.classList.add('invalid');
-    emailError.innerHTML = emailForm.value.trim() ? '올바른 이메일 주소가 아닙니다.' : '이메일을 입력해 주세요.';
+emailInput.addEventListener('focusout', function () {
+  if (!emailInput.value.includes('@')) {
+    emailInput.classList.add('invalid');
+    emailError.innerHTML = emailInput.value.trim() ? '올바른 이메일 주소가 아닙니다.' : '이메일을 입력해 주세요.';
   } else {
-    emailForm.classList.remove('invalid');
+    emailInput.classList.remove('invalid');
     emailError.innerHTML = '';
   }
 });
 
 //password 에러 메시지 호출
-passwordForm.addEventListener('focusout', function () {
-  if (!passwordForm.value.trim()) {
-    passwordForm.classList.add('invalid');
+passwordInput.addEventListener('focusout', function () {
+  if (!passwordInput.value.trim()) {
+    passwordInput.classList.add('invalid');
     passwordError.innerHTML = '비밀번호를 입력해 주세요.';
   } else {
-    passwordForm.classList.remove('invalid');
+    passwordInput.classList.remove('invalid');
     passwordError.innerHTML = '';
   }
 });
@@ -36,10 +36,10 @@ function login() {
   if (emailValue === validEmail && passwordValue === validPassword) {
     window.location.href = './folder';
   } else if (emailValue !== validEmail) {
-    emailForm.classList.add('invalid');
+    emailInput.classList.add('invalid');
     emailError.innerHTML = '이메일을 확인해 주세요.';
   } else if (passwordValue !== validPassword) {
-    passwordForm.classList.add('invalid');
+    passwordInput.classList.add('invalid');
     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
   }
 }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본]이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?
- [x] [기본]로그인 버튼 클릭 또는 Enter키 입력으로 로그인 되나요?

### 심화

- [ ] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

## 주요 변경사항

- 로그인 에러 메시지 처리
- 로그인 버튼 클릭 이벤트 구현

## 스크린샷

<img width="634" alt="스크린샷 2024-01-21 오후 7 05 23" src="https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/144193370/9760c826-321f-4c0b-9477-3b8c2adc712b">

## 멘토에게

- 유효하지 않은 비밀번호 입력 에러 메시지를 구현하지 못했습니다. 아이디 입력은 같은 방식으로 이벤트를 줬을 때 유효하지 않은 아이디 입력 에러 메시지가 뜨는데, 왜 비밀번호 입력 에러 메시지가 작동하지 않는지 이유를 찾지 못했습니다.
- 로그인 버튼 엔터키 keydown 이벤트를 구현하지 못했습니다.
- 더 나은 커밋 메시지 작성 방법을 서칭하면서 커밋 방식을 중간에 바꿨습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
