### PR TITLE
[이유승] Week4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "liveServer.settings.port": 5501
-}

--- a/signin/index.html
+++ b/signin/index.html
@@ -47,5 +47,6 @@
       </div>
     </footer>
   </div>
+  <script src="index.js"></script>
 </body>
 </html>

--- a/signin/index.html
+++ b/signin/index.html
@@ -19,7 +19,7 @@
     </header>
     <section>
       <div class="contents-frame">
-        <form class="contents-form">
+        <form class="contents-form" action="/folder.html" onsubmit="return login()">
           <label for="email">이메일</label>
           <input type="email" name="email" id="email" placeholder="이메일">
           <label for="password">비밀번호</label>

--- a/signin/index.js
+++ b/signin/index.js
@@ -1,0 +1,39 @@
+// email input 포커스 아웃을 했는데 값이 없을때
+let email = document.querySelector('#email');
+let form = document.querySelector('.contents-form');
+
+function emailNoneValue() {
+  const emailErrMessage = '이메일을 입력해 주세요.';
+  const errorElement = document.createElement('div');
+  errorElement.classList.add('error-message');
+
+  if (email.value.trim() === '') {
+    errorElement.textContent = emailErrMessage;
+    form.insertBefore(errorElement, email.nextSibling);
+  } else {
+    // 이메일이 비어 있지 않으면 오류 메시지를 제거합니다.
+    let existingError = form.querySelector('.error-message');
+    if (existingError) {
+      form.removeChild(existingError);
+    }
+  }
+}
+
+email.addEventListener('focusout', emailNoneValue);
+
+// email input 포커스 아웃을 했는데 이메일 형식에 맞지 않을때
+
+function emailValidation() {
+  const emailVaildErrMessage = '올바른 이메일 주소가 아닙니다.';
+  const emailRegExp = /^[a-zA-z0-9._-]+@[a-zA-z0-9.-]+\.[a-zA-z.]+$/;
+  const errorElement = document.createElement('div');
+  errorElement.classList.add('error-message');
+
+  // 이메일 형식이 올바르지 않은 경우 에러 메시지 표시
+  if (email.value.trim() !== '' && !emailRegExp.test(email)) {
+    errorElement.textContent = emailVaildErrMessage;
+    form.insertBefore(errorElement, email.nextSibling);
+  }
+}
+
+email.addEventListener('focusout', emailValidation);

--- a/signin/index.js
+++ b/signin/index.js
@@ -89,10 +89,14 @@ function login(event) {
     const errorElementEmail = document.createElement('div');
     errorElementEmail.classList.add('error-message-email');
     errorElementEmail.textContent = '이메일을 확인해 주세요.';
+    email.style.borderColor = '#FF5B56';
+    errorElementEmail.style.color = '#FF5B56'
 
     const errorElementPW = document.createElement('div');
     errorElementPW.classList.add('error-message-password');
     errorElementPW.textContent = '비밀번호를 확인해 주세요.';
+    password.style.borderColor = '#FF5B56';
+    errorElementPW.style.borderColor = '#FF5B56';
 
     email.parentNode.insertBefore(errorElementEmail, email.nextSibling);
     pwContainer.appendChild(errorElementPW);

--- a/signin/index.js
+++ b/signin/index.js
@@ -10,6 +10,8 @@ function emailNoneValue() {
   if (email.value.trim() === '') {
     errorElement.textContent = emailErrMessage;
     form.insertBefore(errorElement, email.nextSibling);
+    email.style.borderColor = '#FF5B56';
+    errorElement.style.color = '#FF5B56';
   } else {
     // 이메일이 비어 있지 않으면 오류 메시지를 제거합니다.
     let existingError = form.querySelector('.error-message');
@@ -25,15 +27,45 @@ email.addEventListener('focusout', emailNoneValue);
 
 function emailValidation() {
   const emailVaildErrMessage = '올바른 이메일 주소가 아닙니다.';
-  const emailRegExp = /^[a-zA-z0-9._-]+@[a-zA-z0-9.-]+\.[a-zA-z.]+$/;
+  const emailRegExp = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z.]+$/;
   const errorElement = document.createElement('div');
   errorElement.classList.add('error-message');
 
   // 이메일 형식이 올바르지 않은 경우 에러 메시지 표시
-  if (email.value.trim() !== '' && !emailRegExp.test(email)) {
+  if (email.value.trim() !== '' && !emailRegExp.test(email.value.trim())) {
     errorElement.textContent = emailVaildErrMessage;
     form.insertBefore(errorElement, email.nextSibling);
+    email.style.borderColor = '#FF5B56';
+    errorElement.style.color = '#FF5B56';
   }
+  // Q: 올바른 이메일 형식일때 input border를 원래대로 되돌리는 방법을 모르겠어요!
+  // Q: 그리고 focusout을 여러번 하면 오류메세지가 여러번 뜨는데 중복되게 한 번만 뜨게 하는 방법 알고싶어요.
 }
 
 email.addEventListener('focusout', emailValidation);
+
+let password = document.querySelector('#password'); // 비밀번호 input 요소
+let pwContainer = document.querySelector('.password-container');
+
+// 비밀번호 input 포커스 아웃을 했을 때 값이 없을 때
+function passwordNoneValue() {
+  const passwordErrMessage = '비밀번호를 입력해 주세요.';
+  const errorElement = document.createElement('div');
+  errorElement.classList.add('error-message');
+
+  if (password.value.trim() === '') {
+    errorElement.textContent = passwordErrMessage;
+    pwContainer.appendChild(errorElement);
+    password.style.borderColor = '#FF5B56';
+    errorElement.style.color = '#FF5B56';
+    errorElement.style.marginTop= '6px';
+  } else {
+    // 비밀번호가 비어 있지 않으면 오류 메시지를 제거합니다.
+    let existingError = pwContainer.querySelector('.error-message');
+    if (existingError) {
+      pwContainer.removeChild(existingError);
+    }
+  }
+}
+
+password.addEventListener('focusout', passwordNoneValue);

--- a/signin/index.js
+++ b/signin/index.js
@@ -96,7 +96,7 @@ function login(event) {
     errorElementPW.classList.add('error-message-password');
     errorElementPW.textContent = '비밀번호를 확인해 주세요.';
     password.style.borderColor = '#FF5B56';
-    errorElementPW.style.borderColor = '#FF5B56';
+    errorElementPW.style.color = '#FF5B56';
 
     email.parentNode.insertBefore(errorElementEmail, email.nextSibling);
     pwContainer.appendChild(errorElementPW);

--- a/signin/index.js
+++ b/signin/index.js
@@ -69,3 +69,37 @@ function passwordNoneValue() {
 }
 
 password.addEventListener('focusout', passwordNoneValue);
+
+function login(event) {
+  event.preventDefault(); // Prevents the default form submission behavior
+
+  // Remove existing error messages
+  let existingErrorEmail = form.querySelector('.error-message-email');
+  if (existingErrorEmail) {
+    form.removeChild(existingErrorEmail);
+  }
+
+  let existingErrorPW = pwContainer.querySelector('.error-message-password');
+  if (existingErrorPW) {
+    pwContainer.removeChild(existingErrorPW);
+  }
+
+  if (email.value == "test@codeit.com" && password.value == "codeit101") {
+    // If login is successful, redirect to /folder or perform other actions
+    window.location.href = "/folder";
+  } else {
+    const errorElementEmail = document.createElement('div');
+    errorElementEmail.classList.add('error-message-email');
+    errorElementEmail.textContent = '이메일을 확인해 주세요.';
+
+    const errorElementPW = document.createElement('div');
+    errorElementPW.classList.add('error-message-password');
+    errorElementPW.textContent = '비밀번호를 확인해 주세요.';
+
+    // Insert new error messages below the input fields
+    email.parentNode.insertBefore(errorElementEmail, email.nextSibling);
+    pwContainer.appendChild(errorElementPW);
+  }
+}
+
+form.addEventListener('submit', login);

--- a/signin/index.js
+++ b/signin/index.js
@@ -71,9 +71,8 @@ function passwordNoneValue() {
 password.addEventListener('focusout', passwordNoneValue);
 
 function login(event) {
-  event.preventDefault(); // Prevents the default form submission behavior
+  event.preventDefault();
 
-  // Remove existing error messages
   let existingErrorEmail = form.querySelector('.error-message-email');
   if (existingErrorEmail) {
     form.removeChild(existingErrorEmail);
@@ -85,7 +84,6 @@ function login(event) {
   }
 
   if (email.value == "test@codeit.com" && password.value == "codeit101") {
-    // If login is successful, redirect to /folder or perform other actions
     window.location.href = "/folder";
   } else {
     const errorElementEmail = document.createElement('div');
@@ -96,7 +94,6 @@ function login(event) {
     errorElementPW.classList.add('error-message-password');
     errorElementPW.textContent = '비밀번호를 확인해 주세요.';
 
-    // Insert new error messages below the input fields
     email.parentNode.insertBefore(errorElementEmail, email.nextSibling);
     pwContainer.appendChild(errorElementPW);
   }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?


- [x] [기본]이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


- [x] [기본]로그인 버튼 클릭 또는 Enter키 입력으로 로그인 되나요?

### 심화

- [ ] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

## 주요 변경사항

- 로그인 기능을 변경했습니다.
-

## 스크린샷

![이메일 값 없을때 오류](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/127082479/b2252abf-a722-4d12-9092-dde586d90cd0)
![이메일 형식 잘못됐을때](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/127082479/44d841bc-5144-46cb-80e5-0773b3ac98ee)
![비밀번호 값 없을때](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/127082479/9e08d2c7-4321-4b2c-9078-317f105ec998)
![로그인 잘못 시도 시](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/127082479/b91aec7c-2ec2-48dd-af1d-44912b17e28c)


## 멘토에게

- // Q: 주석으로 질문 남겼습니다.
- 시간이 없어 완성도가 떨어진 채로 제출하게 되어서 다음주에 더 보충해서 제출하도록 하겠습니다.
- 저번주 코드리뷰 해주신 것도 반영을 못해서 다음주 제출때 이번주꺼랑 같이 수정하겠습니다!!
- 이메일, 비밀번호 오류 메세지의 정렬이 안 맞는 건 HTML 코드 문제인거겠죠?