### PR TITLE
[이우혁] Week5

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -91,7 +91,7 @@ body{
 }
 
 
-#signin--input--email, #signin--input--password{
+.signin--input--email, .signin--input--password{
     padding: 1.125rem 0.9375rem;
     border-radius: 0.5rem;
     background-color: var(--Linkbrary-white);
@@ -100,7 +100,7 @@ body{
     width: calc(100% - 1.875rem);
 }
 
-#signin--input--email:focus, #signin--input--password:focus{
+.signin--input--email:focus, .signin--input--password:focus{
     border: 1px solid var(--Linkbrary-primary-color);
 }
 
@@ -110,6 +110,7 @@ body{
     margin-top: 0.38rem;
     font-weight: 400;
     font-style: normal;
+    display: none;
 }
 
 .signin__button{

--- a/css/signin.css
+++ b/css/signin.css
@@ -51,7 +51,7 @@ body{
     text-align: center;
 }
 
-.signin__title--img{
+.signin__logo{
     width: 13.16144rem;
     height: 2.375rem;
 }
@@ -74,7 +74,7 @@ body{
     gap: 1.88rem;
 }
 
-.signin__input__area{
+.signin__input--area{
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
@@ -91,7 +91,7 @@ body{
 }
 
 
-#signin__input--email, #signin__input--password{
+#signin--input--email, #signin--input--password{
     padding: 1.125rem 0.9375rem;
     border-radius: 0.5rem;
     background-color: var(--Linkbrary-white);
@@ -100,7 +100,7 @@ body{
     width: calc(100% - 1.875rem);
 }
 
-#signin__input--email:focus, #signin__input--password:focus{
+#signin--input--email:focus, #signin--input--password:focus{
     border: 1px solid var(--Linkbrary-primary-color);
 }
 

--- a/css/signup.css
+++ b/css/signup.css
@@ -91,7 +91,7 @@ body{
    margin-bottom: 0.75rem;
 }
 
-#signup--input--email, #signup--input--password, #signup--input--password--confirm{
+.signup--input--email, .signup--input--password, .signup--input--password--confirm{
     padding: 1.125rem 0.9375rem;
     border-radius: 0.5rem;
     background-color: var(--Linkbrary-white);
@@ -100,7 +100,7 @@ body{
     width: calc(100% - 1.875rem);
 }
 
-#signup--input--email:focus, #signup--input--password:focus, #signup--input--password--confirm:focus{
+.signup--input--email:focus, .signup--input--password:focus, .signup--input--password--confirm:focus{
     border: 1px solid var(--Linkbrary-red);
 }
 
@@ -110,6 +110,7 @@ body{
     margin-top: 0.38rem;
     font-weight: 400;
     font-style: normal;
+    display: none;
 }
 
 .signup__button{

--- a/css/signup.css
+++ b/css/signup.css
@@ -51,7 +51,7 @@ body{
     text-align: center;
 }
 
-.signup__title--img{
+.signup__logo{
     width: 13.16144rem;
     height: 2.375rem; 
 }
@@ -75,7 +75,7 @@ body{
     gap: 1.5rem
 }
 
-.signup__input__area{
+.signup__input--area{
     display: flex;
     flex-direction: column;
     gap: 1.2rem
@@ -91,7 +91,7 @@ body{
    margin-bottom: 0.75rem;
 }
 
-#signup__input--email, #signup__input--password, #signup__input--password--confirm{
+#signup--input--email, #signup--input--password, #signup--input--password--confirm{
     padding: 1.125rem 0.9375rem;
     border-radius: 0.5rem;
     background-color: var(--Linkbrary-white);
@@ -100,7 +100,7 @@ body{
     width: calc(100% - 1.875rem);
 }
 
-#signup__input--email:focus, #signup__input--password:focus, #signup__input--password--confirm:focus{
+#signup--input--email:focus, #signup--input--password:focus, #signup--input--password--confirm:focus{
     border: 1px solid var(--Linkbrary-red);
 }
 

--- a/js/signin.js
+++ b/js/signin.js
@@ -3,8 +3,8 @@ import { userInfo } from "./user-info.js";
 import { pwInputTypeChange } from "./pw-input-type.js";
 
 window.onload = function(){
-    const emailInput = document.getElementById("signin--input--email")
-    const pwInput = document.getElementById("signin--input--password");
+    const emailInput = document.querySelector(".signin--input--email")
+    const pwInput = document.querySelector(".signin--input--password");
     const form = document.querySelector(".sigin__form");
     const emailError = document.querySelector(".signin__email--error");
     const pwError = document.querySelector(".signin__password--error");

--- a/js/signin.js
+++ b/js/signin.js
@@ -3,8 +3,8 @@ import { userInfo } from "./user-info.js";
 import { pwInputTypeChange } from "./pw-input-type.js";
 
 window.onload = function(){
-    const emailInput = document.getElementById("signin__input--email")
-    const pwInput = document.getElementById("signin__input--password");
+    const emailInput = document.getElementById("signin--input--email")
+    const pwInput = document.getElementById("signin--input--password");
     const form = document.querySelector(".sigin__form");
     const emailError = document.querySelector(".signin__email--error");
     const pwError = document.querySelector(".signin__password--error");

--- a/js/signup.js
+++ b/js/signup.js
@@ -4,9 +4,9 @@ import { pwInputTypeChange } from "./pw-input-type.js";
 import { regexEamil, regexPassword } from "./regExp.js";
 
 window.onload = function(){
-    const emailInput = document.getElementById("signup__input--email")
-    const pwInput = document.getElementById("signup__input--password");
-    const pwConfirmInput = document.getElementById("signup__input--password--confirm");
+    const emailInput = document.getElementById("signup--input--email")
+    const pwInput = document.getElementById("signup--input--password");
+    const pwConfirmInput = document.getElementById("signup--input--password--confirm");
     const form = document.querySelector(".signup__form");
     const pwEyeIcon = document.querySelector(".eye");
     const pwConfirmEyeIcon = document.querySelector(".eye--confirm");

--- a/js/signup.js
+++ b/js/signup.js
@@ -4,9 +4,9 @@ import { pwInputTypeChange } from "./pw-input-type.js";
 import { regexEamil, regexPassword } from "./regExp.js";
 
 window.onload = function(){
-    const emailInput = document.getElementById("signup--input--email")
-    const pwInput = document.getElementById("signup--input--password");
-    const pwConfirmInput = document.getElementById("signup--input--password--confirm");
+    const emailInput = document.querySelector(".signup--input--email")
+    const pwInput = document.querySelector(".signup--input--password");
+    const pwConfirmInput = document.querySelector(".signup--input--password--confirm");
     const form = document.querySelector(".signup__form");
     const pwEyeIcon = document.querySelector(".eye");
     const pwConfirmEyeIcon = document.querySelector(".eye--confirm");

--- a/js/vaild.js
+++ b/js/vaild.js
@@ -3,38 +3,45 @@ import { regexEamil, regexPassword } from "./regExp.js";
 
 function vaildEmail(emailInput, emailError, emailDuplication = true) {
     if(!emailInput.value){
+        emailError.style.display = "block";
         emailError.textContent = "이메일을 입력해 주세요.";
     }
     else if(!regexEamil.test(emailInput.value)){
+        emailError.style.display = "block";
         emailError.textContent = "올바른 이메일 주소가 아닙니다.";
     }
     else if(emailDuplication && (userInfo['email'] === emailInput.value)){
+        emailError.style.display = "block";
         emailError.textContent = "이미 사용 중인 이메일입니다.";
     }else{
-        emailError.textContent = "";
+        emailError.style.display = "none";
     }
 }
 
 function vaildPW(pwInput, pwError, pwLength = true){
     if(!pwInput.value){
+        pwError.style.display = "block";
         pwError.textContent = "비밀번호를 입력해 주세요.";
     }
     else if(pwLength && (!regexPassword.test(pwInput.value))){
+        pwError.style.display = "block";
         pwError.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
     }else{
-        pwError.textContent = "";
+        pwError.style.display = "none";
     }
 }
 
 function vaildConfirmPW(pwInput, pwError, pwLength = true){
     if(!pwInput.value){
+        pwError.style.display = "block";
         pwError.textContent = "비밀번호를 입력해 주세요.";
     }
     else if(pwLength && (!regexPassword.test(pwInput.value))){
+        pwError.style.display = "block";
         pwError.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
     }
     else{
-        pwError.textContent = "";
+        pwError.style.display = "none";
     }
 }
 

--- a/signin.html
+++ b/signin.html
@@ -26,17 +26,17 @@
                 <div class="signin__input--area">
                     <!-- 이메일 -->
                     <div class="signin__email">
-                        <label class="signin__label" for="emailInput">이메일</label>
-                        <input id="signin--input--email" type="email" name="email" required>
-                        <div class="signin__email--error"></div>
+                        <label class="signin__label" for="input--email">이메일</label>
+                        <input id="input--email" class="signin--input--email" type="email" name="email" required>
+                        <p class="signin__email--error"></p>
                     </div>
                     <!-- 비밀번호 -->
                     <div class="signin__password">
-                        <label class="signin__label" for="pwInput">비밀번호</label>
+                        <label class="signin__label" for="input--password">비밀번호</label>
                         <div class="signin__password--relative">
-                            <input id="signin--input--password" type="password" name="pw" required>
+                            <input id="input--password" class="signin--input--password" type="password" name="pw" required>
                             <i class="fa-solid fa-eye"></i>
-                            <div class="signin__password--error"></div>
+                            <p class="signin__password--error"></p>
                         </div>
                     </div>
                 </div>

--- a/signin.html
+++ b/signin.html
@@ -18,23 +18,23 @@
         <div class="signin__box">
             <!-- 메인 문구 영역(타이틀, 회원가입 링크) -->
             <div class="signin__title">
-                <a href="index.html"><img class="signin__title--img" src="./img/logo.svg" alt="로고 이미지"></a>
-                <div class="signin__text">회원이 아니신가요? <a class="signin__text--register" href="signup.html">회원 가입하기</a></div>
+                <a href="index.html"><img class="signin__logo" src="./img/logo.svg" alt="로고 이미지"></a>
+                <p class="signin__text">회원이 아니신가요? <a class="signin__text--register" href="signup.html">회원 가입하기</a></p>
             </div>
             <!-- 폼 태그 -->
             <form class="sigin__form">
-                <div class="signin__input__area">
+                <div class="signin__input--area">
                     <!-- 이메일 -->
                     <div class="signin__email">
                         <label class="signin__label" for="emailInput">이메일</label>
-                        <input id="signin__input--email" type="email" name="email" required>
+                        <input id="signin--input--email" type="email" name="email" required>
                         <div class="signin__email--error"></div>
                     </div>
                     <!-- 비밀번호 -->
                     <div class="signin__password">
                         <label class="signin__label" for="pwInput">비밀번호</label>
                         <div class="signin__password--relative">
-                            <input id="signin__input--password" type="password" name="pw" required>
+                            <input id="signin--input--password" type="password" name="pw" required>
                             <i class="fa-solid fa-eye"></i>
                             <div class="signin__password--error"></div>
                         </div>

--- a/signin.html
+++ b/signin.html
@@ -27,7 +27,7 @@
                     <!-- 이메일 -->
                     <div class="signin__email">
                         <label class="signin__label" for="input--email">이메일</label>
-                        <input id="input--email" class="signin--input--email" type="email" name="email" required>
+                        <input id="input--email" class="signin--input--email" type="email" name="email" required autofocus>
                         <p class="signin__email--error"></p>
                     </div>
                     <!-- 비밀번호 -->

--- a/signup.html
+++ b/signup.html
@@ -25,7 +25,7 @@
                     <!-- 이메일 -->
                     <div class="signup__email">
                         <label class="signup__label" for="input--email">이메일</label>
-                        <input id="input--email" class="signup--input--email" type="email" name="email" required>
+                        <input id="input--email" class="signup--input--email" type="email" name="email" required autofocus>
                         <p class="signup__email--error"></p>
                     </div>
                     <!-- 비밀번호 -->

--- a/signup.html
+++ b/signup.html
@@ -24,26 +24,26 @@
                 <div class="signup__input--area">
                     <!-- 이메일 -->
                     <div class="signup__email">
-                        <label class="signup__label" for="emailInput">이메일</label>
-                        <input id="signup--input--email" type="email" name="email" required>
-                        <div class="signup__email--error"></div>
+                        <label class="signup__label" for="input--email">이메일</label>
+                        <input id="input--email" class="signup--input--email" type="email" name="email" required>
+                        <p class="signup__email--error"></p>
                     </div>
                     <!-- 비밀번호 -->
                     <div class="signup__password">
-                        <label class="signup__label" for="pwInput">비밀번호</label>
+                        <label class="signup__label" for="input--password">비밀번호</label>
                         <div class="signin__password--relative">
-                            <input id="signup--input--password" type="password" name="pw" required>
+                            <input id="input--password" class="signup--input--password" type="password" name="pw" required>
                             <i class="fa-solid fa-eye eye"></i>
-                            <div class="signup__password--error"></div>
+                            <p class="signup__password--error"></p>
                         </div>
                     </div>
                     <!-- 비밀번호 확인 -->
                     <div class="signup__password--confirm">
-                        <label class="signup__label" for="pwInput2">비밀번호 확인</label>
+                        <label class="signup__label" for="input--password--confirm">비밀번호 확인</label>
                         <div class="signin__password--confirm--relative">
-                            <input id="signup--input--password--confirm" type="password" name="pw2" required>
+                            <input id="input--password--confirm" class="signup--input--password--confirm" type="password" name="pw2" required>
                             <i class="fa-solid fa-eye eye--confirm"></i>
-                            <div class="signup__password--confirm--error"></div>
+                            <p class="signup__password--confirm--error"></p>
                         </div>
                     </div>
                 </div>

--- a/signup.html
+++ b/signup.html
@@ -16,23 +16,23 @@
         <div class="signup__box">
             <!-- 메인 문구 영역(타이틀, 로그인 링크) -->
             <div class="signup__title">
-                <a href="index.html"><img class="signup__title--img" src="./img/logo.svg" alt="로고 이미지"></a>
-                <div class="signup__text">이미 회원이신가요? <a class="signup__text--login" href="signin.html"> 로그인 하기</a></div>
+                <a href="index.html"><img class="signup__logo" src="./img/logo.svg" alt="로고 이미지"></a>
+                <p class="signup__text">이미 회원이신가요? <a class="signup__text--login" href="signin.html"> 로그인 하기</a></p>
             </div>
             <!-- 폼 태그 -->
             <form class="signup__form">
-                <div class="signup__input__area">
+                <div class="signup__input--area">
                     <!-- 이메일 -->
                     <div class="signup__email">
                         <label class="signup__label" for="emailInput">이메일</label>
-                        <input id="signup__input--email" type="email" name="email" required>
+                        <input id="signup--input--email" type="email" name="email" required>
                         <div class="signup__email--error"></div>
                     </div>
                     <!-- 비밀번호 -->
                     <div class="signup__password">
                         <label class="signup__label" for="pwInput">비밀번호</label>
                         <div class="signin__password--relative">
-                            <input id="signup__input--password" type="password" name="pw" required>
+                            <input id="signup--input--password" type="password" name="pw" required>
                             <i class="fa-solid fa-eye eye"></i>
                             <div class="signup__password--error"></div>
                         </div>
@@ -41,7 +41,7 @@
                     <div class="signup__password--confirm">
                         <label class="signup__label" for="pwInput2">비밀번호 확인</label>
                         <div class="signin__password--confirm--relative">
-                            <input id="signup__input--password--confirm" type="password" name="pw2" required>
+                            <input id="signup--input--password--confirm" type="password" name="pw2" required>
                             <i class="fa-solid fa-eye eye--confirm"></i>
                             <div class="signup__password--confirm--error"></div>
                         </div>


### PR DESCRIPTION
## 요구사항

### 기본
- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?


## 멘토에게

- 저번주 말씀해 주신 부분들 피드백 반영해서 크게 달라진 부분은 없습니다!

- 만약에 더 피드백 해주실 부분 있으시면 피드백 주셔도 좋습니다🙃