### PR TITLE
[정기환] Week5

### DIFF
--- a/css/sign.css
+++ b/css/sign.css
@@ -59,7 +59,8 @@ input:focus {
   border: 1px solid var(--primary-color);
 }
 
-.sign-in-button {
+.sign-in-button,
+.sign-up-button {
   display: flex;
   width: 100%;
   padding: 16px 20px;

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
     </div>
 
     <footer>
-      <p class="copyright">&copy;codei - 2023</p>
+      <p class="copyright">&copy;codeit - 2023</p>
       <div class="footer-text">
         <a href="privacy.html">Privacy Policy</a
         ><a class="faq-text" href="faq.html">FAQ</a>

--- a/js/sign.js
+++ b/js/sign.js
@@ -1,50 +1,52 @@
-const userid = document.querySelector("#email");
-const userpw = document.querySelector("#password");
-const userpwCheck = document.querySelector("#password-check");
+const userID = document.querySelector("#email");
+const userPW = document.querySelector("#password");
+const userPWCheck = document.querySelector("#password-check");
 const emailError = document.querySelector(".emailError");
 const pwError = document.querySelector(".pwError");
 const signInButton = document.querySelector(".sign-in-button");
-const eye = document.querySelectorAll(".eye");
-const lineThrough = document.querySelectorAll(".line-through");
+const pwContainer = document.querySelector(".pw-container");
+const checkPWContainer = document.querySelector(".check-pw-container");
+
+function errorStyle(textStyle, boxStyle) {
+  textStyle.style.color = "red";
+  boxStyle.style.border = "1px solid red";
+}
+
+function clearStyle(textStyle, boxStyle) {
+  textStyle.textContent = "";
+  boxStyle.style.border = "";
+}
 
 function validEmail(obj) {
   if (obj.value === "") {
     emailError.textContent = "이메일을 입력해주세요.";
-    emailError.style.color = "red";
-    userid.style.border = "1px solid red";
+    errorStyle(emailError, userID);
   } else if (validEmailCheck(obj) == false) {
-    console.log(obj.value);
     emailError.textContent = "올바른 이메일 주소가 아닙니다.";
-    emailError.style.color = "red";
-    userid.style.border = "1px solid red";
+    errorStyle(emailError, userID);
   } else {
-    emailError.textContent = "";
-    userid.style.border = "";
+    clearStyle(emailError, userID);
   }
 }
 
 function validPassword(obj) {
   if (obj.value === "") {
     pwError.textContent = "비밀번호를 입력해주세요.";
-    pwError.style.color = "red";
-    userpw.style.border = "1px solid red";
+    errorStyle(pwError, userPW);
   } else {
-    pwError.textContent = "";
-    userpw.style.border = "";
+    clearStyle(pwError, userPW);
   }
 }
 
 function goUrl() {
-  if (userid.value === "test@codeit.com" && userpw.value === "codeit101") {
+  if (userID.value === "test@codeit.com" && userPW.value === "codeit101") {
     let link = "folder/";
     location.href = link;
   } else {
     emailError.textContent = "이메일을 확인해주세요.";
-    emailError.style.color = "red";
-    userid.style.border = "1px solid red";
+    errorStyle(emailError, userID);
     pwError.textContent = "비밀번호를 확인해주세요.";
-    pwError.style.color = "red";
-    userpw.style.border = "1px solid red";
+    errorStyle(pwError, userPW);
   }
 }
 
@@ -55,39 +57,31 @@ function enterLogin(e) {
 }
 
 function validEmailCheck(obj) {
-  var pattern =
+  let pattern =
     /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-  return obj.value.match(pattern) != null;
+  return !!obj.value.match(pattern);
 }
 
 function showPW(e) {
-  if (userpw.type === "password") {
-    userpw.type = "text";
-    lineThrough[0].style.display = "block";
-  } else {
-    userpw.type = "password";
-    lineThrough[0].style.display = "none";
-  }
+  const lineThrough = this.querySelector(".line-through");
+  const pwInput = this.querySelector("#password");
+  if (e.target.classList.contains("eyePW"))
+    if (pwInput.type === "password") {
+      pwInput.type = "text";
+      lineThrough.style.display = "block";
+    } else {
+      pwInput.type = "password";
+      lineThrough.style.display = "none";
+    }
 }
 
-//For sign-up.html
-function showPWCheck(e) {
-  if (userpwCheck.type === "password") {
-    userpwCheck.type = "text";
-    lineThrough[1].style.display = "block";
-  } else {
-    userpwCheck.type = "password";
-    lineThrough[1].style.display = "none";
-  }
-}
-
-userid.addEventListener("focusout", (e) => {
+userID.addEventListener("focusout", (e) => {
   validEmail(e.target);
 });
-userpw.addEventListener("focusout", (e) => {
+userPW.addEventListener("focusout", (e) => {
   validPassword(e.target);
 });
 signInButton.addEventListener("click", goUrl);
 document.addEventListener("keypress", enterLogin);
-eye[0].addEventListener("click", showPW);
-eye[1].addEventListener("click", showPWCheck);
+pwContainer.addEventListener("click", showPW);
+checkPWContainer.addEventListener("click", showPW);

--- a/js/signIn.js
+++ b/js/signIn.js
@@ -1,11 +1,9 @@
 const userID = document.querySelector("#email");
 const userPW = document.querySelector("#password");
-const userPWCheck = document.querySelector("#password-check");
 const emailError = document.querySelector(".emailError");
 const pwError = document.querySelector(".pwError");
 const signInButton = document.querySelector(".sign-in-button");
 const pwContainer = document.querySelector(".pw-container");
-const checkPWContainer = document.querySelector(".check-pw-container");
 
 function errorStyle(textStyle, boxStyle) {
   textStyle.style.color = "red";
@@ -33,15 +31,22 @@ function validPassword(obj) {
   if (obj.value === "") {
     pwError.textContent = "비밀번호를 입력해주세요.";
     errorStyle(pwError, userPW);
+  } else if (validPasswordCheck(obj) == false) {
+    pwError.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+    errorStyle(pwError, userPW);
   } else {
     clearStyle(pwError, userPW);
   }
 }
 
 function goUrl() {
+  let link = "folder/";
+  location.href = link;
+}
+
+function validSignIn() {
   if (userID.value === "test@codeit.com" && userPW.value === "codeit101") {
-    let link = "folder/";
-    location.href = link;
+    goUrl();
   } else {
     emailError.textContent = "이메일을 확인해주세요.";
     errorStyle(emailError, userID);
@@ -51,14 +56,17 @@ function goUrl() {
 }
 
 function enterLogin(e) {
-  if (e.keyCode === 13) {
-    goUrl();
-  }
+  if (e.keyCode === 13) validSignIn();
 }
 
 function validEmailCheck(obj) {
   let pattern =
     /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+  return !!obj.value.match(pattern);
+}
+
+function validPasswordCheck(obj) {
+  let pattern = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
   return !!obj.value.match(pattern);
 }
 
@@ -81,7 +89,21 @@ userID.addEventListener("focusout", (e) => {
 userPW.addEventListener("focusout", (e) => {
   validPassword(e.target);
 });
-signInButton.addEventListener("click", goUrl);
-document.addEventListener("keypress", enterLogin);
+if (signInButton) {
+  signInButton.addEventListener("click", validSignIn);
+  document.addEventListener("keypress", enterLogin);
+}
 pwContainer.addEventListener("click", showPW);
-checkPWContainer.addEventListener("click", showPW);
+
+export {
+  userID,
+  userPW,
+  emailError,
+  pwError,
+  errorStyle,
+  clearStyle,
+  validEmailCheck,
+  goUrl,
+  validPasswordCheck,
+  showPW,
+};

--- a/js/signUp.js
+++ b/js/signUp.js
@@ -1,0 +1,79 @@
+import {
+  userID,
+  userPW,
+  emailError,
+  pwError,
+  errorStyle,
+  clearStyle,
+  validEmailCheck,
+  goUrl,
+  validPasswordCheck,
+  showPW,
+} from "./signIn.js";
+
+const userPWCheck = document.querySelector(".check-password");
+const checkPWError = document.querySelector(".check-pw-error");
+const signUpButton = document.querySelector(".sign-up-button");
+const checkPWContainer = document.querySelector(".check-pw-container");
+
+let isValidPasswordCheck = false;
+
+function isValidEmail(obj) {
+  if (obj.value !== "" && validEmailCheck(obj) === true) return true;
+}
+
+function isValidPassword(obj) {
+  if (obj.value !== "" && validPasswordCheck(obj) === true) return true;
+}
+
+function validSignUp() {
+  if (isValidEmail(userID) && isValidPassword(userPW) && isValidPasswordCheck) {
+    goUrl();
+  }
+  if (isValidEmail(userID) !== true) {
+    emailError.textContent = "이메일을 다시 확인주세요!";
+    errorStyle(emailError, userID);
+  }
+  if (isValidPassword(userPW) !== true) {
+    pwError.textContent = "비밀번호를 다시 확인해주세요!";
+    errorStyle(pwError, userPW);
+  }
+  if (isValidPasswordCheck !== true) {
+    errorStyle(checkPWError, userPWCheck);
+    checkPWError.textContent = "비밀번호를 일치시켜주세요!";
+  }
+}
+
+function enterLogin(e) {
+  if (e.keyCode === 13) validSignUp();
+}
+
+function emailAlreadyExist(obj) {
+  if (obj.value === "test@codeit.com") {
+    emailError.textContent = "이미 사용 중인 이메일입니다.";
+    errorStyle(emailError, userID);
+  }
+}
+
+function checkPassword(obj) {
+  if (obj.value === userPW.value) {
+    clearStyle(checkPWError, userPWCheck);
+    isValidPasswordCheck = true;
+  } else {
+    errorStyle(checkPWError, userPWCheck);
+    checkPWError.textContent = "비밀번호가 일치하지 않아요.";
+    isValidPasswordCheck = false;
+  }
+}
+
+userID.addEventListener("focusout", (e) => {
+  emailAlreadyExist(e.target);
+  isValidEmail(e.target);
+});
+userPWCheck.addEventListener("focusout", (e) => {
+  checkPassword(e.target);
+  isValidPassword(e.target);
+});
+signUpButton.addEventListener("click", validSignUp);
+document.addEventListener("keypress", enterLogin);
+checkPWContainer.addEventListener("click", showPW);

--- a/sign_in.html
+++ b/sign_in.html
@@ -47,6 +47,6 @@
         </div>
       </div>
     </div>
-    <script src="js/sign.js"></script>
+    <script type="module" src="js/signIn.js"></script>
   </body>
 </html>

--- a/sign_in.html
+++ b/sign_in.html
@@ -27,7 +27,7 @@
       <div class="input-container">
         <label for="password">비밀번호</label>
         <div class="pw-container">
-          <img class="eye" src="images/eye.svg" />
+          <img class="eyePW" src="images/eye.svg" />
           <span class="line-through"></span>
           <input type="password" id="password" placeholder="********" />
         </div>

--- a/sign_up.html
+++ b/sign_up.html
@@ -38,11 +38,17 @@
         <div class="pw-container check-pw-container">
           <img class="eyePW" src="images/eye.svg" />
           <span class="line-through"></span>
-          <input type="password" id="password" placeholder="********" />
+          <input
+            type="password"
+            class="check-password"
+            id="password"
+            placeholder="********"
+          />
         </div>
+        <span class="check-pw-error"></span>
       </div>
 
-      <button class="sign-in-button">회원가입</button>
+      <button class="sign-up-button">회원가입</button>
       <div class="social-login">
         <p>다른 방식으로 가입하기</p>
         <div class="icon-container">
@@ -55,6 +61,6 @@
         </div>
       </div>
     </div>
-    <script src="js/sign.js"></script>
+    <script type="module" src="js/signUp.js"></script>
   </body>
 </html>

--- a/sign_up.html
+++ b/sign_up.html
@@ -27,7 +27,7 @@
       <div class="input-container">
         <label for="password">비밀번호</label>
         <div class="pw-container">
-          <img class="eye" src="images/eye.svg" />
+          <img class="eyePW" src="images/eye.svg" />
           <span class="line-through"></span>
           <input type="password" id="password" placeholder="********" />
         </div>
@@ -35,10 +35,10 @@
       </div>
       <div class="input-container">
         <label for="password">비밀번호 확인</label>
-        <div class="pw-container">
-          <img class="eye" src="images/eye.svg" />
+        <div class="pw-container check-pw-container">
+          <img class="eyePW" src="images/eye.svg" />
           <span class="line-through"></span>
-          <input type="password" id="password-check" placeholder="********" />
+          <input type="password" id="password" placeholder="********" />
         </div>
       </div>
 


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- sign.js를 signIn.js, signUp.js로 분리시킨 뒤 모듈화 시켰습니다.


## 스크린샷

![image](이미지url)

## 멘토에게

-
```javascript
if (signInButton) {
  signInButton.addEventListener("click", validSignIn);
  document.addEventListener("keypress", enterLogin);
}
``` 
모듈화를 시키니까 signUp 페이지인데도 불구하고 signIn.js에서

![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/8645321/a62b6aa4-7c88-4a06-8d2f-c5fbb1ba9503)
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/8645321/73918a83-52f5-47d1-9b7b-ee42f52bda77)

이러한 에러가 발생했습니다. 분명 import, export에서는 관련 함수와 변수를 모듈화 시키지 않았는데도요...
if문으로 감싸서 signInButton이 없으면 동작하지 않게 해놨긴 했는데 더 좋은 방법이 보이신다면 알려주세요.

