### PR TITLE
[김재영]Week5

### DIFF
--- a/sign.css
+++ b/sign.css
@@ -103,7 +103,8 @@ body {
   gap: 12px;
 }
 .email__error-msg,
-.pw__error-msg {
+.pw__error-msg,
+.pw-repeat__error-msg {
   display: none;
   color: var(--Linkbrary-red, #ff5b56);
   font-family: 'Pretendard';

--- a/signFunctions.js
+++ b/signFunctions.js
@@ -142,3 +142,45 @@ export function signupPasswordCorrectCheck(
     inputBorderGray(pwInputRepeat, pwError);
   }
 }
+
+//회원가입 버튼 동작 메서드
+export function signUp(
+  emailInput,
+  pwInput,
+  pwInputRepeat,
+  emailError,
+  pwError,
+  pwRepeatError,
+  pwOnOffImg
+) {
+  const checkList = [true, true, true];
+  if (
+    !emailInput.value ||
+    emailFormatCheck(emailInput.value) === false ||
+    emailInput.value === 'test@codeit.com'
+  ) {
+    emailError.innerHTML = '이메일을 확인해 주세요.';
+    inputBorderRed(emailInput, emailError);
+    checkList[0] = false;
+  }
+  if (
+    pwInput.value.length < 8 ||
+    Number(pwInput.value) ||
+    /^[a-zA-Z]+$/.test(pwInput.value)
+  ) {
+    pwError.innerHTML = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+    pwOnOffImg[0].style.bottom = '2.9375rem';
+    inputBorderRed(pwInput, pwError);
+    checkList[1] = false;
+  }
+  if (pwInput.value !== pwInputRepeat.value) {
+    pwRepeatError.innerHTML = '비밀번호가 일치하는지 확인해주세요.';
+    pwOnOffImg[1].style.bottom = '2.9375rem';
+    inputBorderRed(pwInputRepeat, pwRepeatError);
+    checkList[2] = false;
+  }
+
+  if (!checkList.includes(false)) {
+    window.location.href = './folder.html';
+  }
+}

--- a/signFunctions.js
+++ b/signFunctions.js
@@ -90,3 +90,16 @@ export function passwordVisibleSwitch(isPasswordVisible, pwOnOffImg, pwInput) {
     isPasswordVisible[0] = false;
   }
 }
+
+//회원가입 비밀번호 값 에러 확인 메서드
+export function signupPasswordErrorCheck(pwInput, pwError, pwOnOffImg) {
+  const pwValue = pwInput.value;
+  if (pwValue.length < 8 || Number(pwValue) || /^[a-zA-Z]+$/.test(pwValue)) {
+    pwError.innerHTML = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+    pwOnOffImg.style.bottom = '2.9375rem';
+    inputBorderRed(pwInput, pwError);
+  } else {
+    pwOnOffImg.style.bottom = '1.1875rem';
+    inputBorderGray(pwInput, pwError);
+  }
+}

--- a/signFunctions.js
+++ b/signFunctions.js
@@ -33,7 +33,8 @@ export function signIn(emailInput, pwInput, emailError, pwError, pwOnOffImg) {
 }
 
 // 이메일 에러 검사 메서드
-// 작성 되었는지, 유효한 이메일인지 검사
+
+// 1. 작성 되었는지, 유효한 이메일인지 검사
 export function emailErrorCheck(inputElement, errorElement) {
   const emailValue = inputElement.value;
   if (!emailValue) {
@@ -44,6 +45,22 @@ export function emailErrorCheck(inputElement, errorElement) {
     inputBorderRed(inputElement, errorElement);
   } else {
     inputBorderGray(inputElement, errorElement);
+  }
+}
+// 2. 회원가입에서 사용중인 이메일인지 검사(1번 내용 포함)
+export function usingEmailCheck(emailInput, emailError) {
+  const emailValue = emailInput.value;
+  if (!emailValue) {
+    emailError.innerHTML = '이메일을 입력해 주세요.';
+    inputBorderRed(emailInput, emailError);
+  } else if (emailFormatCheck(emailValue) === false) {
+    emailError.innerHTML = '올바른 이메일 주소가 아닙니다.';
+    inputBorderRed(emailInput, emailError);
+  } else if (emailInput.value === 'test@codeit.com') {
+    emailError.innerHTML = '이미 사용중인 이메일 입니다.';
+    inputBorderRed(emailInput, emailError);
+  } else {
+    inputBorderGray(emailInput, emailError);
   }
 }
 

--- a/signFunctions.js
+++ b/signFunctions.js
@@ -79,6 +79,7 @@ export function signinPasswordErrorCheck(pwInput, pwError, pwOnOffImg) {
 }
 
 //비밀번호 보여주기 스위치 메서드
+//1.로그인 페이지용
 export function passwordVisibleSwitch(isPasswordVisible, pwOnOffImg, pwInput) {
   if (!isPasswordVisible[0]) {
     pwOnOffImg.src = './icons/eyeson.png';
@@ -87,6 +88,27 @@ export function passwordVisibleSwitch(isPasswordVisible, pwOnOffImg, pwInput) {
   } else {
     pwOnOffImg.src = './icons/eyesoff.png';
     pwInput.type = 'password';
+    isPasswordVisible[0] = false;
+  }
+}
+//2.회원가입 페이지용(한 클릭으로 두 input 모두 제어)
+export function signupPasswordVisibleSwitch(
+  isPasswordVisible,
+  pwOnOffImg,
+  pwInput,
+  pwInputRepeat
+) {
+  if (!isPasswordVisible[0]) {
+    pwOnOffImg[0].src = './icons/eyeson.png';
+    pwOnOffImg[1].src = './icons/eyeson.png';
+    pwInput.type = 'none';
+    pwInputRepeat.type = 'none';
+    isPasswordVisible[0] = true;
+  } else {
+    pwOnOffImg[0].src = './icons/eyesoff.png';
+    pwOnOffImg[1].src = './icons/eyesoff.png';
+    pwInput.type = 'password';
+    pwInputRepeat.type = 'password';
     isPasswordVisible[0] = false;
   }
 }
@@ -101,5 +123,22 @@ export function signupPasswordErrorCheck(pwInput, pwError, pwOnOffImg) {
   } else {
     pwOnOffImg.style.bottom = '1.1875rem';
     inputBorderGray(pwInput, pwError);
+  }
+}
+
+//회원가입 비밀번호확인 일치 여부 메서드
+export function signupPasswordCorrectCheck(
+  pwInput,
+  pwInputRepeat,
+  pwError,
+  pwOnOffImg
+) {
+  if (pwInput.value !== pwInputRepeat.value) {
+    pwError.innerHTML = '비밀번호가 일치하지 않아요.';
+    pwOnOffImg.style.bottom = '2.9375rem';
+    inputBorderRed(pwInputRepeat, pwError);
+  } else {
+    pwOnOffImg.style.bottom = '1.1875rem';
+    inputBorderGray(pwInputRepeat, pwError);
   }
 }

--- a/signFunctions.js
+++ b/signFunctions.js
@@ -1,0 +1,75 @@
+//이메일 유효성 검사 메서드
+export function emailFormatCheck(email) {
+  const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  return email_regex.test(email);
+}
+
+/*파랑(focus), 빨강(error), 그레이(default) 색으로 border변경,
+  각 상태에 따라서 error msg block,none 결정 매서드 */
+export function inputBorderBlue(element) {
+  element.style.outline = 'none';
+  element.style.border = '1px solid #6d6afe';
+}
+export function inputBorderRed(inputElement, errorElement) {
+  inputElement.style.border = '1px solid var(--Linkbrary-red,#FF5B56)';
+  errorElement.style.display = 'block';
+}
+export function inputBorderGray(inputElement, errorElement) {
+  inputElement.style.border = '1px solid var(--Linkbrary-gray20, #CCD5E3)';
+  errorElement.style.display = 'none';
+}
+
+//로그인 기능 매서드
+export function signIn(emailInput, pwInput, emailError, pwError, pwOnOffImg) {
+  if (emailInput.value == 'test@codeit.com' && pwInput.value == 'codeit101') {
+    window.location.href = './folder.html';
+  } else {
+    emailError.innerHTML = '이메일을 확인해 주세요.';
+    pwError.innerHTML = '비밀번호를 확인해 주세요.';
+    inputBorderRed(emailInput, emailError);
+    pwOnOffImg.style.bottom = '2.9375rem';
+    inputBorderRed(pwInput, pwError);
+  }
+}
+
+// 이메일 에러 검사 메서드
+// 작성 되었는지, 유효한 이메일인지 검사
+export function emailErrorCheck(inputElement, errorElement) {
+  const emailValue = inputElement.value;
+  if (!emailValue) {
+    errorElement.innerHTML = '이메일을 입력해 주세요.';
+    inputBorderRed(inputElement, errorElement);
+  } else if (emailFormatCheck(emailValue) === false) {
+    errorElement.innerHTML = '올바른 이메일 주소가 아닙니다.';
+    inputBorderRed(inputElement, errorElement);
+  } else {
+    inputBorderGray(inputElement, errorElement);
+  }
+}
+
+//로그인시 비밀번호 에러 확인 메서드
+export function signinPasswordErrorCheck(pwInput, pwError, pwOnOffImg) {
+  const pwValue = pwInput.value;
+
+  if (!pwValue) {
+    pwError.innerHTML = '비밀번호를 입력해 주세요.';
+    pwOnOffImg.style.bottom = '2.9375rem';
+    inputBorderRed(pwInput, pwError);
+  } else {
+    pwOnOffImg.style.bottom = '1.1875rem';
+    inputBorderGray(pwInput, pwError);
+  }
+}
+
+//비밀번호 보여주기 스위치 메서드
+export function passwordVisibleSwitch(isPasswordVisible, pwOnOffImg, pwInput) {
+  if (!isPasswordVisible[0]) {
+    pwOnOffImg.src = './icons/eyeson.png';
+    pwInput.type = 'none';
+    isPasswordVisible[0] = true;
+  } else {
+    pwOnOffImg.src = './icons/eyesoff.png';
+    pwInput.type = 'password';
+    isPasswordVisible[0] = false;
+  }
+}

--- a/signin.html
+++ b/signin.html
@@ -21,7 +21,7 @@
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="212"
-              height="38"
+              height="38"`
               viewBox="0 0 212 38"
               fill="none"
             >

--- a/signin.html
+++ b/signin.html
@@ -144,5 +144,5 @@
       </section>
     </main>
   </body>
-  <script src="signin.js"></script>
+  <script type="module" src="signin.js"></script>
 </html>

--- a/signin.js
+++ b/signin.js
@@ -1,103 +1,43 @@
+import * as signFunctions from './signFunctions.js';
+
 const emailInput = document.getElementById('signin-email');
 const pwInput = document.getElementById('signin-pw');
 const pwOnOffImg = document.getElementById('pw-onoff');
-let isPasswordVisible = false;
+let isPasswordVisible = [false];
 const signButton = document.getElementById('signin-button');
 const emailError = document.getElementById('email__error-msg');
 const pwError = document.getElementById('pw__error-msg');
 
-//이메일 유효성 검사 메서드
-function emailCheck(email) {
-  const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
-  return email_regex.test(email);
-}
-
-/*파랑(focus), 빨강(error), 그레이(default) 색으로 border변경,
-  각 상태에 따라서 error msg block,none 결정 매서드 */
-function inputBorderBlue(element) {
-  element.style.outline = 'none';
-  element.style.border = '1px solid #6d6afe';
-}
-function inputBorderRed(inputElement, errorElement) {
-  inputElement.style.border = '1px solid var(--Linkbrary-red,#FF5B56)';
-  errorElement.style.display = 'block';
-}
-function inputBorderGray(inputElement, errorElement) {
-  inputElement.style.border = '1px solid var(--Linkbrary-gray20, #CCD5E3)';
-  errorElement.style.display = 'none';
-}
-
 // focus in 시에 파란색테두리 변경
 emailInput.addEventListener('focus', function () {
-  inputBorderBlue(emailInput);
+  signFunctions.inputBorderBlue(emailInput);
 });
 pwInput.addEventListener('focus', function () {
-  inputBorderBlue(pwInput);
+  signFunctions.inputBorderBlue(pwInput);
 });
 
-// 이메일 에러 검사 메서드
-// 작성 되었는지, 유효한 이메일인지 검사
+//focus out 시에 에러 검사
 emailInput.addEventListener('focusout', function () {
-  const emailValue = emailInput.value;
-
-  if (!emailValue) {
-    emailError.innerHTML = '이메일을 입력해 주세요.';
-    inputBorderRed(emailInput, emailError);
-  } else if (emailCheck(emailValue) === false) {
-    emailError.innerHTML = '올바른 이메일 주소가 아닙니다.';
-    inputBorderRed(emailInput, emailError);
-  } else {
-    inputBorderGray(emailInput, emailError);
-  }
+  signFunctions.emailErrorCheck(emailInput, emailError);
 });
 
-//비밀번호 작성 되었는지 검사
 pwInput.addEventListener('focusout', function () {
-  const pwValue = pwInput.value;
-
-  if (!pwValue) {
-    pwError.innerHTML = '비밀번호를 입력해 주세요.';
-    pwOnOffImg.style.bottom = '2.9375rem';
-    inputBorderRed(pwInput, pwError);
-  } else {
-    pwOnOffImg.style.bottom = '1.1875rem';
-    inputBorderGray(pwInput, pwError);
-  }
+  signFunctions.signinPasswordErrorCheck(pwInput, pwError, pwOnOffImg);
 });
 
-//비밀번호 확인 기능 매서드
+//비밀번호 확인기능
 pwOnOffImg.addEventListener('click', function () {
-  if (!isPasswordVisible) {
-    pwOnOffImg.src = './icons/eyeson.png';
-    pwInput.type = 'none';
-    isPasswordVisible = true;
-  } else {
-    pwOnOffImg.src = './icons/eyesoff.png';
-    pwInput.type = 'password';
-    isPasswordVisible = false;
-  }
+  signFunctions.passwordVisibleSwitch(isPasswordVisible, pwOnOffImg, pwInput);
 });
 
-//로그인 기능 매서드
-function signIn(email, password) {
-  if (email == 'test@codeit.com' && password == 'codeit101') {
-    window.location.href = './folder.html';
-  } else {
-    emailError.innerHTML = '이메일을 확인해 주세요.';
-    pwError.innerHTML = '비밀번호를 확인해 주세요.';
-    inputBorderRed(emailInput, emailError);
-    pwOnOffImg.style.bottom = '2.9375rem';
-    inputBorderRed(pwInput, pwError);
-  }
-}
 //버튼에 클릭,엔터 이벤트시에 로그인 함수 기능 추가
 signButton.addEventListener('click', function (e) {
   e.preventDefault();
-  signIn(emailInput.value, pwInput.value);
+  signFunctions.signIn(emailInput, pwInput, emailError, pwError, pwOnOffImg);
 });
 signButton.addEventListener('keypress', function (e) {
   e.preventDefault();
   if (e.key === 'Enter') {
-    signIn(emailInput.value, pwInput.value);
+    signFunctions.signIn(emailInput, pwInput, emailError, pwError, pwOnOffImg);
   }
 });

--- a/signin.js
+++ b/signin.js
@@ -1,7 +1,7 @@
 const emailInput = document.getElementById('signin-email');
 const pwInput = document.getElementById('signin-pw');
 const pwOnOffImg = document.getElementById('pw-onoff');
-let pwSwitch = false;
+let isPasswordVisible = false;
 const signButton = document.getElementById('signin-button');
 const emailError = document.getElementById('email__error-msg');
 const pwError = document.getElementById('pw__error-msg');
@@ -67,21 +67,21 @@ pwInput.addEventListener('focusout', function () {
 
 //비밀번호 확인 기능 매서드
 pwOnOffImg.addEventListener('click', function () {
-  if (!pwSwitch) {
+  if (!isPasswordVisible) {
     pwOnOffImg.src = './icons/eyeson.png';
     pwInput.type = 'none';
-    pwSwitch = true;
+    isPasswordVisible = true;
   } else {
     pwOnOffImg.src = './icons/eyesoff.png';
     pwInput.type = 'password';
-    pwSwitch = false;
+    isPasswordVisible = false;
   }
 });
 
 //로그인 기능 매서드
 function signIn(email, password) {
   if (email == 'test@codeit.com' && password == 'codeit101') {
-    window.location.replace('./folder.html');
+    window.location.href = './folder.html';
   } else {
     emailError.innerHTML = '이메일을 확인해 주세요.';
     pwError.innerHTML = '비밀번호를 확인해 주세요.';

--- a/signup.html
+++ b/signup.html
@@ -77,7 +77,7 @@
           <div class="sign__form--pw">
             <label for="signin-pw">비밀번호</label>
             <input type="password" name="signin-pw" id="signin-pw" />
-            <img src="./icons/eyesoff.png" alt="eyesoff" id="pw-onoff">
+            <img src="./icons/eyesoff.png" alt="eyesoff" class="pw-onoff" id="pw-onoff">
           </div>
           <div class="sign__form--pw2">
             <label for="signin-pw-repeat">비밀번호 확인</label>
@@ -86,10 +86,10 @@
               name="signin-pw-repeat"
               id="signin-pw-repeat"
             />
-            <img src="./icons/eyesoff.png" alt="eyesoff" id="pw-onoff">
+            <img src="./icons/eyesoff.png" alt="eyesoff" class="pw-onoff" id="pw-onoff">
           </div>
-          <button class="sign__form--button">
-            <a href="./index.html">회원가입</a>
+          <button class="sign__form--button" id="signin-button">
+            회원가입
           </button>
         </form>
         

--- a/signup.html
+++ b/signup.html
@@ -9,7 +9,7 @@
     crossorigin
     href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
   />
-    <title>Signin</title>
+    <title>Signup</title>
     <link rel="stylesheet" href="./sign.css" />
   </head>
   <body>
@@ -152,4 +152,5 @@
       </section>
     </main>
   </body>
+  <script src="signin.js"></script>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -71,24 +71,27 @@
         </div>
         <form class="sign__form">
           <div class="sign__form--email">
-            <label for="signin-email">이메일</label>
-            <input type="email" name="signin-email" id="signin-email" />
+            <label for="signup-email">이메일</label>
+            <input type="email" name="signup-email" id="signup-email" />
+            <div class="email__error-msg" id="email__error-msg"></div>
           </div>
           <div class="sign__form--pw">
-            <label for="signin-pw">비밀번호</label>
-            <input type="password" name="signin-pw" id="signin-pw" />
+            <label for="signup-pw">비밀번호</label>
+            <input type="password" name="signup-pw" id="signup-pw" />
+            <div class="pw__error-msg" id="pw__error-msg"></div>
             <img src="./icons/eyesoff.png" alt="eyesoff" class="pw-onoff" id="pw-onoff">
           </div>
           <div class="sign__form--pw2">
-            <label for="signin-pw-repeat">비밀번호 확인</label>
+            <label for="signup-pw-repeat">비밀번호 확인</label>
             <input
               type="password"
-              name="signin-pw-repeat"
-              id="signin-pw-repeat"
+              name="signup-pw-repeat"
+              id="signup-pw-repeat"
             />
+            <div class="pw-repeat__error-msg" id="pw-repeat__error-msg"></div>
             <img src="./icons/eyesoff.png" alt="eyesoff" class="pw-onoff" id="pw-onoff">
           </div>
-          <button class="sign__form--button" id="signin-button">
+          <button class="sign__form--button" id="signup-button">
             회원가입
           </button>
         </form>
@@ -152,5 +155,5 @@
       </section>
     </main>
   </body>
-  <script src="signin.js"></script>
+  <script type="module" src="./signup.js"></script>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,27 @@
+import * as signFunctions from './signFunctions.js';
+
+const emailInput = document.querySelector('#signup-email');
+const pwInput = document.querySelector('#signup-pw');
+const pwInputRepeat = document.querySelector('#signup-pw-repeat');
+const pwOnOffImg = document.querySelectorAll('#pw-onoff');
+let isPasswordVisible = [false];
+const signButton = document.getElementById('signup-button');
+const emailError = document.getElementById('email__error-msg');
+const pwError = document.getElementById('pw__error-msg');
+const pwRepeatError = document.getElementById('pw-repeat__error-msg');
+
+//focus in event
+emailInput.addEventListener('focus', function () {
+  signFunctions.inputBorderBlue(emailInput);
+});
+pwInput.addEventListener('focus', function () {
+  signFunctions.inputBorderBlue(pwInput);
+});
+pwInputRepeat.addEventListener('focus', function () {
+  signFunctions.inputBorderBlue(pwInputRepeat);
+});
+
+//focus out event
+emailInput.addEventListener('focusout', function () {
+  signFunctions.emailErrorCheck(emailInput, emailError);
+});

--- a/signup.js
+++ b/signup.js
@@ -25,3 +25,7 @@ pwInputRepeat.addEventListener('focus', function () {
 emailInput.addEventListener('focusout', function () {
   signFunctions.usingEmailCheck(emailInput, emailError);
 });
+
+pwInput.addEventListener('focusout', function () {
+  signFunctions.signupPasswordErrorCheck(pwInput, pwError, pwOnOffImg[0]);
+});

--- a/signup.js
+++ b/signup.js
@@ -23,5 +23,5 @@ pwInputRepeat.addEventListener('focus', function () {
 
 //focus out event
 emailInput.addEventListener('focusout', function () {
-  signFunctions.emailErrorCheck(emailInput, emailError);
+  signFunctions.usingEmailCheck(emailInput, emailError);
 });

--- a/signup.js
+++ b/signup.js
@@ -29,3 +29,23 @@ emailInput.addEventListener('focusout', function () {
 pwInput.addEventListener('focusout', function () {
   signFunctions.signupPasswordErrorCheck(pwInput, pwError, pwOnOffImg[0]);
 });
+
+pwInputRepeat.addEventListener('focusout', function () {
+  signFunctions.signupPasswordCorrectCheck(
+    pwInput,
+    pwInputRepeat,
+    pwRepeatError,
+    pwOnOffImg[1]
+  );
+});
+
+pwOnOffImg.forEach(function (e) {
+  e.addEventListener('click', function () {
+    signFunctions.signupPasswordVisibleSwitch(
+      isPasswordVisible,
+      pwOnOffImg,
+      pwInput,
+      pwInputRepeat
+    );
+  });
+});

--- a/signup.js
+++ b/signup.js
@@ -49,3 +49,30 @@ pwOnOffImg.forEach(function (e) {
     );
   });
 });
+
+signButton.addEventListener('click', function (e) {
+  e.preventDefault();
+  signFunctions.signUp(
+    emailInput,
+    pwInput,
+    pwInputRepeat,
+    emailError,
+    pwError,
+    pwRepeatError,
+    pwOnOffImg
+  );
+});
+signButton.addEventListener('keypress', function (e) {
+  e.preventDefault();
+  if (e.key === 'Enter') {
+    signFunctions.signUp(
+      emailInput,
+      pwInput,
+      pwInputRepeat,
+      emailError,
+      pwError,
+      pwRepeatError,
+      pwOnOffImg
+    );
+  }
+});


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항
5주차 위클리미션 기능 구현 했습니다.

## 스크린샷
- 이메일 에러 메시지
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/79738890/72c3485a-b748-49b0-8896-40a8de00b467)

![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/79738890/99974605-e68e-44f5-96eb-2e3646cedc19)

- 비밀번호 에러 메시지
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/79738890/92d43203-7f67-42ac-9501-273761778e24)

- 비밀번호 스위치 작동
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/79738890/3bba482a-3102-4302-a041-af693a3a2b09)


## 멘토에게
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
