### PR TITLE
[김가은99] week5

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
         </nav>
         <div class="content1">
             <div class = "title">
-                <p><span class = "hl">세상의 모든 정보</span>를</p> 
+                <p><strong class = "hl">세상의 모든 정보</strong>를</p> 
                 <p>쉽게 저장하고 관리해 보세요</p>
             </div>
             <button onclick = "location.href = './signup/signup.html'" class="addlink">링크 추가하기</button>
@@ -27,7 +27,7 @@
         <div class="content2">
             <div class="text">
                 <div class="subtitle">
-                    <span class="want_link">원하는 링크</span>를 저장하세요
+                    <strong class="want_link">원하는 링크</strong>를 저장하세요
                 </div>
                 <div class="explain">
                     나중에 읽고 싶은 글, 다시 보고 싶은 영상,
@@ -41,7 +41,7 @@
             <img class="img" src="image/landing/img 4.png" alt = "링크로 관리" >
             <div class="text">
                 <div class="subtitle">
-                    링크를 폴더로 <span class="manage">관리</span>하세요
+                    링크를 폴더로 <strong class="manage">관리</strong>하세요
                 </div>
                 <div class="explain">
                     나만의 폴더를 무제한으로 만들고 
@@ -52,7 +52,7 @@
         <div class="content2">
             <div class="text">
                 <div class="subtitle">
-                    저장한 링크를 <span class="share">공유</span>해 보세요.
+                    저장한 링크를 <strong class="share">공유</strong>해 보세요.
                 </div>
                 <div class="explain">
                     여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.
@@ -64,7 +64,7 @@
             <img class="img" src="image/landing/_img4 1.png" alt = "링크 검색" >
             <div class="text">
                 <div class="subtitle">
-                    정장한 링크를 <span class="manage">검색</span>해 보세요
+                    정장한 링크를 <strong class="manage">검색</strong>해 보세요
                 </div>
                 <div class="explain">
                     중요한 정보들을 검색으로 쉽게 찾아보세요.

--- a/landing.css
+++ b/landing.css
@@ -75,7 +75,7 @@ nav>#login{
 .title>p{
     margin:0;
 }
-.title p>.hl{
+.title>p>.hl{
     background: linear-gradient(91deg, #6D6AFE 17.28%, #FF9F9F 74.98%);
     background-clip: text;
     -webkit-background-clip: text;

--- a/signin/signin.css
+++ b/signin/signin.css
@@ -115,7 +115,7 @@ body{
     z-index:1;
     outline: none;
     border-radius: 8px;
-    border: 1px solid red;
+    border: 1px solid var(--Linkbrary-red);
     background: var(--Linkbrary-white);
 }
 

--- a/signin/signin.html
+++ b/signin/signin.html
@@ -11,7 +11,7 @@
         <link rel="stylesheet" href="signin.css">
         <script src="signin.js"></script>
     </head>
-    <body onkeydown="Enter_login()">
+    <body onkeydown="enterLogin()">
         <div class="content">
             <div class="title">
                 <a class="logo" href="./"><img src="../image/signin/logo.svg" alt = "logo"></a>
@@ -22,7 +22,7 @@
             </div>
             <div class = "info">
                 <p>이메일</p>
-                <input id ="email" class="focus_blue" type="text" name="email" oninput = "email_check()">
+                <input id ="email" class="focus_blue" type="text" name="email" oninput = "emailCheck()">
                 <p class ="email_result result"></p>
             </div>
             <div class = "info">

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -1,10 +1,11 @@
-﻿let regex = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
+﻿const regex = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 
-function email_check(){
+function emailCheck(){
     const email = document.querySelector("#email");
     if (!email.value){
         document.querySelector('.email_result').innerText = "이메일을 입력해주세요";
         email.classList.add('focus_red');
+        return;
     }
     else if (!regex.test(email.value)){
         document.querySelector('.email_result').innerText = "올바른 이메일 주소가 아닙니다.";
@@ -32,7 +33,7 @@ function login(){
     }
 }
 
-function Enter_login(){
+function enterLogin(){
     const key_code = window.event.keyCode;
     if (key_code == 13){
         login();

--- a/signup/signup.css
+++ b/signup/signup.css
@@ -6,6 +6,7 @@
     --gra-purpleblue-to-skyblue: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
     --Grey-Light: #F5F5F5;
     --Linkbrary-gray10: #E7EFFB;
+    --Linkbrary-red: #FF5B56;
 }
 
 * {
@@ -108,13 +109,38 @@ body{
     background: var(--Linkbrary-white);
 }
 
+.focus_red{
+    z-index:1;
+    outline: none;
+    border-radius: 8px;
+    border: 1px solid var(--Linkbrary-red);
+    background: var(--Linkbrary-white);
+}
+
+.focus_red:focus{
+    z-index:1;
+    outline: none;
+    border-radius: 8px;
+    border: 1px solid var(--Linkbrary-red);
+    background: var(--Linkbrary-white);
+}
+
 .check{
+    z-index: 10;
     position: absolute;
     right:15px;
     width: 16px;
     height: 16px;
 }
 
+.result{
+    color: var(--Linkbrary-red);
+    font-family: Pretendard;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+}
 
 #signup{
     display: flex;

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -22,20 +22,23 @@
             <div class = "info">
                 <p>이메일</p>
                 <input id ="email" class = "focus_blue" type="text" name="email">
+                <p class ="email_result result"></p>
             </div>
             <div class = "info">
                 <p>비밀번호</p>
                 <div>
                     <input id ="pwd" class = "focus_blue" type="password" name="pwd">
-                    <img class="check" src="../image/signin/eye-on.svg" alt ="비밀번호 보기">
+                    <img class="check" src="../image/signin/eye-off.svg" alt ="비밀번호 보기">
                 </div>
+                <p class ="pwd_result result"></p>
             </div>
             <div class = "info">
                 <p>비밀번호 확인</p>
                 <div>
                     <input id ="repwd" class = "focus_blue" type="password" name="repwd">
-                    <img class="check" src="../image/signin/eye-on.svg" alt = "비밀번호 보기">
+                    <img class="check" src="../image/signin/eye-off.svg" alt = "비밀번호 보기">
                 </div>
+                <p class ="repwd_result result"></p>
             </div>
             <button id="signup">회원가입</button>
             <div class="sns_signin">
@@ -46,5 +49,6 @@
                 </div>
             </div>
         </div>
+        <script src="signup.js"></script>
     </body>
 </html>

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,0 +1,99 @@
+﻿const emailRegex = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
+const pwdRegex =  /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/
+const email = document.querySelector("#email");
+const pwd = document.querySelector("#pwd");
+const repwd = document.querySelector("#repwd");
+const signupBtn = document.querySelector("#signup");
+const body = document.querySelector("body");
+const activeimgs = document.querySelectorAll(".check");
+
+function emailCheck(e){
+    if (!e.target.value){
+        document.querySelector('.email_result').innerText = "이메일을 입력해주세요";
+        e.target.classList.add('focus_red');
+        return;
+    }
+    else if (!emailRegex.test(e.target.value)){
+        document.querySelector('.email_result').innerText = "올바른 이메일 주소가 아닙니다.";
+        e.target.classList.add('focus_red');
+        return
+    }
+    else if (e.target.value == "test@codeit.com"){
+        document.querySelector('.email_result').innerText = "이미 사용 중인 이메일입니다.";
+        e.target.classList.add('focus_red');
+        return
+    }
+    else{
+        document.querySelector('.email_result').innerText = "";
+        e.target.classList.remove('focus_red');
+    }
+    // console.log(e.target.value)
+}
+
+function pwdCheck(e){
+    if (!pwdRegex.test(e.target.value)){
+        document.querySelector('.pwd_result').innerText = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+        e.target.classList.add('focus_red');
+        return
+    }
+    else{
+        document.querySelector('.pwd_result').innerText = "";
+        e.target.classList.remove('focus_red');
+    }
+}
+
+function repwdCheck(e){
+    if(pwd.value != e.target.value){
+        document.querySelector('.repwd_result').innerText = "비밀번호가 일치하지 않아요.";
+        e.target.classList.add('focus_red');
+        return
+    }
+    else{
+        document.querySelector('.repwd_result').innerText = "";
+        e.target.classList.remove('focus_red');
+    }  
+}
+
+function signup(){
+    console.log("hi")
+    checkEmail = document.querySelector('.email_result').innerText
+    checkPwd = document.querySelector('.pwd_result').innerText
+    checkRepwd = document.querySelector('.repwd_result').innerText
+    if (checkEmail ==='' && checkPwd =='' && checkRepwd==''){
+        window.location.href='../folder.html';
+    }
+
+}
+
+function enterSignup(e){
+    if (e.key==='Enter'){
+        signup()
+    }
+}
+
+function active(e){
+    const sibling = e.target.previousElementSibling;
+    console.log(sibling)
+    sibling.classList.toggle('active')
+    
+    if (sibling.classList.contains('active')){
+        sibling.type = "text"
+        e.target.src="../image/signin/eye-on.svg"
+    }
+    else{
+        sibling.type = "password"
+        e.target.src="../image/signin/eye-off.svg"
+    }
+}
+
+email.addEventListener("input", emailCheck);
+pwd.addEventListener("input",pwdCheck);
+repwd.addEventListener("input",repwdCheck);
+signupBtn.addEventListener("click",signup);
+body.addEventListener("keydown",enterSignup);
+for (activeimg of activeimgs){
+    activeimg.addEventListener("click",active)
+}
+
+
+


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x]  [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x]  [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x]  [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x]  [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x]  [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ]  [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 코드리뷰 진행했습니다!
- onchange 가 아닌 oninput  으로 입력받을때 마다 반응하도록 진행했습니다!

## 스크린샷

netlify 주소 - https://65b8c80e1fff7ac5db3da6f9--resplendent-rabanadas-37eff4.netlify.app/

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
