### PR TITLE
[이진호] Week5

### DIFF
--- a/js/jsUtil.js
+++ b/js/jsUtil.js
@@ -1,0 +1,31 @@
+import { focusing, eyeBlink, checkingEmail, checkingPassword, checkingPasswordRepeat, fetchSignin, fetchSignUp } from './signin.js';
+
+// 이메일 관련 요소들
+const email = document.getElementById('email');
+const emailErrorMessage = document.getElementById('error-email');
+
+// 비밀번호 관련 요소들
+const password = document.getElementById('password');
+const passwordErrorMessage = document.getElementById('error-password');
+
+// 비밀번호 확인 관련 요소들
+const passwordRepeat = document.getElementById("passwordR");
+const passwordRepeatErrorMessage = document.getElementById('error-passwordR');
+
+// 눈 관련 요소들
+const eyeButton = document.getElementById("eye-button");
+const eye = document.getElementById("eye");
+const eyeButton2 = document.getElementById("eye-button2");
+const eye2 = document.getElementById("eye2");
+
+email.addEventListener('focusin', () => focusing(emailErrorMessage, email));
+email.addEventListener('focusout', () => checkingEmail(email, emailErrorMessage));
+
+password.addEventListener('focusin', () => focusing(passwordErrorMessage, password));
+password.addEventListener('focusout', () => checkingPassword(password, passwordErrorMessage));
+
+eyeButton.addEventListener('click', () => eyeBlink(password, eye));
+eyeButton2.addEventListener('click', () => eyeBlink(passwordRepeat, eye2));
+
+passwordRepeat.addEventListener('focusin', () => focusing(passwordRepeatErrorMessage, passwordRepeat));
+passwordRepeat.addEventListener('focusout', () => checkingPasswordRepeat(password, passwordRepeat, passwordRepeatErrorMessage));

--- a/js/signin.js
+++ b/js/signin.js
@@ -7,6 +7,7 @@ const passwordRepeat = document.getElementById("passwordR");
 const passwordRepeatErrorMessage = document.getElementById('error-passwordR');
 const eyeButton = document.querySelector('.eye-button');
 
+
 const errorMessages = {
     emailRequired: "이메일을 입력해주세요.",
     invalidEmail: "올바른 이메일 주소가 아닙니다.",
@@ -42,33 +43,31 @@ function eyeBlink(input,icon){
 }
  
 //이메일
-function checkingEmail(type){
+function checkingEmail(){
 
     //이메일 체크를 위한 정규식
     const checkEmail = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/;
+
+    const emailTrim = email.value.trim();
 
     //실패시 체크값 디폴트
     isCheckingEmail=false;
 
     //이메일 체크
-    if(email.value.trim()==""){
+    if(emailTrim==""){
         emailErrorMessage.innerHTML=errorMessages.emailRequired;
         email.style.border= "0.1rem solid var(--red)";
-    }else if(checkEmail.test(email.value.trim())){
+    }else if(checkEmail.test(emailTrim)){
         emailErrorMessage.innerHTML="";
-        email.style.border= "0.1rem solid var(--gray20)";
         isCheckingEmail= true;
+        email.style.border= "0.1rem solid var(--gray20)";
     }else{
         emailErrorMessage.innerHTML=errorMessages.invalidEmail;
         email.style.border= "0.1rem solid var(--red)";
     }
 
-    if(type=='signup'){
-        if(email.value.trim()===`test@codeit.com`){
-            emailErrorMessage.innerHTML=errorMessages.duplicateEmail;
-            email.style.border= "0.1rem solid var(--red)";
-        }
-    }
+    //테스트 중
+    //isCheckingEmail ? email.style.border= "0.1rem solid var(--gray20)" : email.style.border= "0.1rem solid var(--red)";
 }
 
 //비밀번호
@@ -77,21 +76,22 @@ function checkingPassword(){
     //비밀번호 체크를 위한 정규식
     const checkPassword = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,30}$/
 
+    const passwordTrim = password.value.trim();
+
     //실패시 체크값 디폴트
     isCheckingPassword=false;
 
     //비밀번호 체크
-    if(password.value.trim()==""){
+    if(passwordTrim==""){
         passwordErrorMessage.innerHTML=errorMessages.passwordRequired;
-        password.style.border= "0.1rem solid var(--red)";
-    }else if(checkPassword.test(password.value.trim())){
+    }else if(checkPassword.test(passwordTrim)){
         passwordErrorMessage.innerHTML="";
-        password.style.border= "0.1rem solid var(--gray20)";
         isCheckingPassword= true;
     }else{
         passwordErrorMessage.innerHTML=errorMessages.invalidPassword;
-        password.style.border= "0.1rem solid var(--red)";
     }
+
+    isCheckingPassword ? password.style.border= "0.1rem solid var(--gray20)" : password.style.border= "0.1rem solid var(--red)";
 }
 
 
@@ -101,17 +101,18 @@ function checkingPasswordRepeat(){
     //실패시 체크값 디폴트
     isCheckingPasswordRepeatEmail= false;
 
-    if(passwordRepeat.value.trim()==""){
+    const passwordRepeatTrim = passwordRepeat.value.trim();
+
+    if(passwordRepeatTrim==""){
         passwordRepeatErrorMessage.innerHTML=errorMessages.passwordRepeatRequired;
-        passwordRepeat.style.border= "0.1rem solid var(--red)";
-    }else if(password.value.trim()==passwordRepeat.value.trim()){
+    }else if(passwordTrim==passwordRepeatTrim){
         passwordRepeatErrorMessage.innerHTML="";
-        passwordRepeat.style.border= "0.1rem solid var(--gray20)";
         isCheckingPasswordRepeatEmail= true;
     }else{
         passwordRepeatErrorMessage.innerHTML=errorMessages.passwordMismatch;
-        passwordRepeat.style.border= "0.1rem solid var(--red)";
     }
+
+    isCheckingPasswordRepeatEmail ? passwordRepeat.style.border= "0.1rem solid var(--gray20)" : passwordRepeat.style.border= "0.1rem solid var(--red)";
 }
 
 //addEventListener를 이용한 체크 시스템
@@ -124,24 +125,48 @@ form.addEventListener("submit",(e)=>{
     console.log(e.target.id);
 
     if(e.target.id ==='signin'){
-        if(email.value.trim()=="test@codeit.com" && password.value.trim()=="codeit101"){
+        if(isCheckingEmail==true && isCheckingPassword==true){
             //폴더 페이지 미완성으로 인한 임시
-            location.href='/folder.html';
-        }else if(email.value.trim()!="test@codeit.com" && password.value.trim()=="codeit101"){
-            emailErrorMessage.innerHTML=errorMessages.checkEmail;
-            email.style.border= "0.1rem solid var(--red)";
-        }else if(email.value.trim()=="test@codeit.com" && password.value.trim()!="codeit101"){
-            passwordErrorMessage.innerHTML=errorMessages.checkPassword;
-            password.style.border= "0.1rem solid var(--red)";
+            const user = {
+                email: emailTrim,
+                password: passwordTrim
+            }
+            const token = "user";
+            fetch('https://bootcamp-api.codeit.kr/api/sign-in',{
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                  },
+                body: JSON.stringify(user)
+            })
+            .then(response => response.ok ? location.href = '/folder.html' : console.error('로그인 실패'))
+            .catch(error => {
+            console.error('Error:', error);
+            });
         }else{
-            emailErrorMessage.innerHTML=errorMessages.checkEmail;
-            email.style.border= "0.1rem solid var(--red)";
-            passwordErrorMessage.innerHTML=errorMessages.checkPassword;
-            password.style.border= "0.1rem solid var(--red)";
+            checkingEmail();
+            checkingPassword();
         }
     }else if(e.target.id ==='signup'){
         if(isCheckingEmail == true && isCheckingPasswordRepeatEmail==true && isCheckingPassword == true){
-            location.href='/folder.html';
+            const user = {
+                email: emailTrim,
+                password: passwordTrim
+            }
+            const token = "user";
+            fetch('https://bootcamp-api.codeit.kr/api/sign-up',{
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Authorization': `Bearer ${token}`
+                  },
+                body: JSON.stringify(user)
+            })
+            .then(response => response.ok ? location.href = '/folder.html' : console.error('회원가입 실패'))
+            .catch(error => {
+            console.error('Error:', error);
+            });
         }else{
             checkingEmail();
             checkingPassword();

--- a/js/signin.js
+++ b/js/signin.js
@@ -5,6 +5,7 @@ const emailErrorMessage =document.getElementById('error-email');
 const passwordErrorMessage = document.getElementById('error-password');
 const passwordRepeat = document.getElementById("passwordR");
 const passwordRepeatErrorMessage = document.getElementById('error-passwordR');
+const eyeButton = document.querySelector('.eye-button');
 
 const errorMessages = {
     emailRequired: "이메일을 입력해주세요.",
@@ -29,7 +30,7 @@ function focusing(errorName,styleName){
 }
 
 //눈 비밀번호 표시 / 미표시
-function eyeBlink(input,icon){
+function eyeBlink(input,icon){ 
     if(input.type=="password"){
         input.type="text";
         icon.src="../images/eye-on.svg"
@@ -46,11 +47,13 @@ function checkingEmail(type){
     //이메일 체크를 위한 정규식
     const checkEmail = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,4}$/;
 
+    //실패시 체크값 디폴트
+    isCheckingEmail=false;
+
     //이메일 체크
     if(email.value.trim()==""){
         emailErrorMessage.innerHTML=errorMessages.emailRequired;
         email.style.border= "0.1rem solid var(--red)";
-        isCheckingEmail= false;
     }else if(checkEmail.test(email.value.trim())){
         emailErrorMessage.innerHTML="";
         email.style.border= "0.1rem solid var(--gray20)";
@@ -58,14 +61,12 @@ function checkingEmail(type){
     }else{
         emailErrorMessage.innerHTML=errorMessages.invalidEmail;
         email.style.border= "0.1rem solid var(--red)";
-        isCheckingEmail= false;
     }
 
     if(type=='signup'){
         if(email.value.trim()===`test@codeit.com`){
             emailErrorMessage.innerHTML=errorMessages.duplicateEmail;
             email.style.border= "0.1rem solid var(--red)";
-            isCheckingEmail= false;
         }
     }
 }
@@ -76,11 +77,13 @@ function checkingPassword(){
     //비밀번호 체크를 위한 정규식
     const checkPassword = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,30}$/
 
+    //실패시 체크값 디폴트
+    isCheckingPassword=false;
+
     //비밀번호 체크
     if(password.value.trim()==""){
         passwordErrorMessage.innerHTML=errorMessages.passwordRequired;
         password.style.border= "0.1rem solid var(--red)";
-        isCheckingPassword= false;
     }else if(checkPassword.test(password.value.trim())){
         passwordErrorMessage.innerHTML="";
         password.style.border= "0.1rem solid var(--gray20)";
@@ -88,15 +91,19 @@ function checkingPassword(){
     }else{
         passwordErrorMessage.innerHTML=errorMessages.invalidPassword;
         password.style.border= "0.1rem solid var(--red)";
-        isCheckingPassword= false;
     }
 }
 
+
+//비밀번호 확인란
 function checkingPasswordRepeat(){
+
+    //실패시 체크값 디폴트
+    isCheckingPasswordRepeatEmail= false;
+
     if(passwordRepeat.value.trim()==""){
         passwordRepeatErrorMessage.innerHTML=errorMessages.passwordRepeatRequired;
         passwordRepeat.style.border= "0.1rem solid var(--red)";
-        isCheckingPasswordRepeatEmail= false;
     }else if(password.value.trim()==passwordRepeat.value.trim()){
         passwordRepeatErrorMessage.innerHTML="";
         passwordRepeat.style.border= "0.1rem solid var(--gray20)";
@@ -104,19 +111,16 @@ function checkingPasswordRepeat(){
     }else{
         passwordRepeatErrorMessage.innerHTML=errorMessages.passwordMismatch;
         passwordRepeat.style.border= "0.1rem solid var(--red)";
-        isCheckingPasswordRepeatEmail= false;
     }
 }
-
-
 
 //addEventListener를 이용한 체크 시스템
 form.addEventListener("submit",(e)=>{
 
-
     //새로고침 방지
     e.preventDefault();
 
+    //타겟 확인
     console.log(e.target.id);
 
     if(e.target.id ==='signin'){

--- a/js/signin.js
+++ b/js/signin.js
@@ -50,18 +50,22 @@ function checkingEmail(type){
     if(email.value.trim()==""){
         emailErrorMessage.innerHTML=errorMessages.emailRequired;
         email.style.border= "0.1rem solid var(--red)";
+        isCheckingEmail= false;
     }else if(checkEmail.test(email.value.trim())){
         emailErrorMessage.innerHTML="";
         email.style.border= "0.1rem solid var(--gray20)";
+        isCheckingEmail= true;
     }else{
         emailErrorMessage.innerHTML=errorMessages.invalidEmail;
         email.style.border= "0.1rem solid var(--red)";
+        isCheckingEmail= false;
     }
 
     if(type=='signup'){
         if(email.value.trim()===`test@codeit.com`){
             emailErrorMessage.innerHTML=errorMessages.duplicateEmail;
             email.style.border= "0.1rem solid var(--red)";
+            isCheckingEmail= false;
         }
     }
 }

--- a/js/signin.js
+++ b/js/signin.js
@@ -56,18 +56,14 @@ function checkingEmail(){
     //이메일 체크
     if(emailTrim==""){
         emailErrorMessage.innerHTML=errorMessages.emailRequired;
-        email.style.border= "0.1rem solid var(--red)";
     }else if(checkEmail.test(emailTrim)){
         emailErrorMessage.innerHTML="";
         isCheckingEmail= true;
-        email.style.border= "0.1rem solid var(--gray20)";
     }else{
         emailErrorMessage.innerHTML=errorMessages.invalidEmail;
-        email.style.border= "0.1rem solid var(--red)";
     }
 
-    //테스트 중
-    //isCheckingEmail ? email.style.border= "0.1rem solid var(--gray20)" : email.style.border= "0.1rem solid var(--red)";
+    isCheckingEmail ? email.style.border= "0.1rem solid var(--gray20)" : email.style.border= "0.1rem solid var(--red)";
 }
 
 //비밀번호
@@ -105,7 +101,7 @@ function checkingPasswordRepeat(){
 
     if(passwordRepeatTrim==""){
         passwordRepeatErrorMessage.innerHTML=errorMessages.passwordRepeatRequired;
-    }else if(passwordTrim==passwordRepeatTrim){
+    }else if(password.value.trim()==passwordRepeatTrim){
         passwordRepeatErrorMessage.innerHTML="";
         isCheckingPasswordRepeatEmail= true;
     }else{
@@ -113,6 +109,60 @@ function checkingPasswordRepeat(){
     }
 
     isCheckingPasswordRepeatEmail ? passwordRepeat.style.border= "0.1rem solid var(--gray20)" : passwordRepeat.style.border= "0.1rem solid var(--red)";
+}
+
+//로그인 정보주고받기
+async function fetchSignin (){
+    try{
+        const user = {
+            email: email.value.trim(),
+            password: password.value.trim()
+        }
+        const token = "user";
+        const response = await fetch('https://bootcamp-api.codeit.kr/api/sign-in',{
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify(user)
+        });
+        response.ok ? (location.href = '/folder.html') : errorMessage();
+
+        async function errorMessage (){
+            const errorMessage = await response.json();
+            console.error(errorMessage.error.message);
+        }
+    }catch(error){
+        console.error(error.message);
+    }
+}
+
+//현재 작업중 추후에 합칠 예정
+async function fetchSignUp (){
+    try{
+        const user = {
+            email: email.value.trim(),
+            password: password.value.trim()
+        }
+        const token = "user";
+        const response = await fetch('https://bootcamp-api.codeit.kr/api/sign-up',{
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+            body: JSON.stringify(user)
+        });
+        response.ok ? (location.href = '/folder.html') : errorMessage();
+
+        async function errorMessage (){
+            const errorMessage = await response.json();
+            console.error(errorMessage.error.message);
+        }
+    }catch(error){
+        console.error(error.message);
+    }
 }
 
 //addEventListener를 이용한 체크 시스템
@@ -124,49 +174,23 @@ form.addEventListener("submit",(e)=>{
     //타겟 확인
     console.log(e.target.id);
 
+    const user = {
+        email: email.value.trim(),
+        password: password.value.trim()
+    }
+    const token = "user";
+
     if(e.target.id ==='signin'){
         if(isCheckingEmail==true && isCheckingPassword==true){
-            //폴더 페이지 미완성으로 인한 임시
-            const user = {
-                email: emailTrim,
-                password: passwordTrim
-            }
-            const token = "user";
-            fetch('https://bootcamp-api.codeit.kr/api/sign-in',{
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                  },
-                body: JSON.stringify(user)
-            })
-            .then(response => response.ok ? location.href = '/folder.html' : console.error('로그인 실패'))
-            .catch(error => {
-            console.error('Error:', error);
-            });
+            fetchSignin();
         }else{
             checkingEmail();
             checkingPassword();
         }
     }else if(e.target.id ==='signup'){
         if(isCheckingEmail == true && isCheckingPasswordRepeatEmail==true && isCheckingPassword == true){
-            const user = {
-                email: emailTrim,
-                password: passwordTrim
-            }
-            const token = "user";
-            fetch('https://bootcamp-api.codeit.kr/api/sign-up',{
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`
-                  },
-                body: JSON.stringify(user)
-            })
-            .then(response => response.ok ? location.href = '/folder.html' : console.error('회원가입 실패'))
-            .catch(error => {
-            console.error('Error:', error);
-            });
+            //현재 작업중...
+            fetchSignUp();
         }else{
             checkingEmail();
             checkingPassword();
@@ -174,3 +198,5 @@ form.addEventListener("submit",(e)=>{
         }
     }
 });
+
+export { focusing, eyeBlink, checkingEmail, checkingPassword, checkingPasswordRepeat, fetchSignin, fetchSignUp };

--- a/signin.html
+++ b/signin.html
@@ -24,17 +24,16 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)" autocomplete="username"/>
+            <input class="sign-input" id="email" autocomplete="username"/>
             <small id="error-email"></small>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" id="password" type="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)" autocomplete="current-password"/>
+            <input class="sign-input" id="password" type="password" autocomplete="current-password"/>
             <small id="error-password"></small>
-            <button class="eye-button" type="button" id="eye-button" onclick="eyeBlink(password,eye)">
+            <button class="eye-button" type="button" id="eye-button">
               <img src="./images/eye-off.svg" id="eye"/>
             </button>
-            
           </div>
         </div>
         <button class="cta" type="submit" id="loginButton">로그인</button>
@@ -51,6 +50,6 @@
         </div>
       </div>
     </div>
-    <script src="./js/signin.js"></script>
+    <script type="module" src="./js/jsUtil.js"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -24,12 +24,12 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)"/>
+            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)" autocomplete="username"/>
             <small id="error-email"></small>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" id="password" type="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)"/>
+            <input class="sign-input" id="password" type="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)" autocomplete="current-password"/>
             <small id="error-password"></small>
             <button class="eye-button" type="button" id="eye-button" onclick="eyeBlink(password,eye)">
               <img src="./images/eye-off.svg" id="eye"/>

--- a/signin.html
+++ b/signin.html
@@ -24,12 +24,12 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" id="email" value="" autoComplete="off" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)"/>
+            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)"/>
             <small id="error-email"></small>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" id="password" type="password" value="" autoComplete="off" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)"/>
+            <input class="sign-input" id="password" type="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)"/>
             <small id="error-password"></small>
             <button class="eye-button" type="button" id="eye-button" onclick="eyeBlink(password,eye)">
               <img src="./images/eye-off.svg" id="eye"/>

--- a/signup.html
+++ b/signup.html
@@ -24,12 +24,12 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" id="email" onfocusout="checkingEmail('signup')" onfocusin="focusing(emailErrorMessage,email)"/>
+            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)" autocomplete="username"/>
             <small id="error-email"></small>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" id="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)"/>
+            <input class="sign-input" type="password" id="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)" autocomplete="current-password"/>
             <small id="error-password"></small>
             <button class="eye-button" type="button" id="eye-button" onclick="eyeBlink(password,eye)">
               <img src="./images/eye-off.svg" id="eye"/>
@@ -37,7 +37,7 @@
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" id="passwordR" onfocusout="checkingPasswordRepeat()" onfocusin="focusing(passwordRepeatErrorMessage,passwordRepeat)"/>
+            <input class="sign-input" type="password" id="passwordR" onfocusout="checkingPasswordRepeat()" onfocusin="focusing(passwordRepeatErrorMessage,passwordRepeat)" autocomplete="current-password"/>
             <small id="error-passwordR"></small>
             <button class="eye-button" type="button" id="eye-button2" onclick="eyeBlink(passwordR,eye2)">
               <img src="./images/eye-off.svg" id="eye2"/>

--- a/signup.html
+++ b/signup.html
@@ -24,22 +24,22 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" id="email" onfocusout="checkingEmail()" onfocusin="focusing(emailErrorMessage,email)" autocomplete="username"/>
+            <input class="sign-input" id="email" autocomplete="username"/>
             <small id="error-email"></small>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" id="password" onfocusout="checkingPassword()" onfocusin="focusing(passwordErrorMessage,password)" autocomplete="current-password"/>
+            <input class="sign-input" type="password" id="password" autocomplete="current-password"/>
             <small id="error-password"></small>
-            <button class="eye-button" type="button" id="eye-button" onclick="eyeBlink(password,eye)">
+            <button class="eye-button" type="button" id="eye-button">
               <img src="./images/eye-off.svg" id="eye"/>
             </button>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" id="passwordR" onfocusout="checkingPasswordRepeat()" onfocusin="focusing(passwordRepeatErrorMessage,passwordRepeat)" autocomplete="current-password"/>
+            <input class="sign-input" type="password" id="passwordR" autocomplete="current-password"/>
             <small id="error-passwordR"></small>
-            <button class="eye-button" type="button" id="eye-button2" onclick="eyeBlink(passwordR,eye2)">
+            <button class="eye-button" type="button" id="eye-button2">
               <img src="./images/eye-off.svg" id="eye2"/>
             </button>
           </div>
@@ -58,6 +58,6 @@
         </div>
       </div>
     </div>
-    <script src="./js/signin.js"></script>
+    <script type="module" src="./js/jsUtil.js"></script>
   </body>
 </html>

--- a/src/sign.css
+++ b/src/sign.css
@@ -165,6 +165,9 @@ small{
   background-color: #f5e14b;
 }
 
+input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0px 1000px white inset; 
+} 
 
 
 


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?

- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-5주차 적용 완료.

## 스크린샷

![image](이미지url)

## 멘토에게

- 하나로 통합했습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
