### PR TITLE
[조한빈] Week5

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,0 +1,17 @@
+const EMAIL_INPUT = document.querySelector('#email');
+const PASSWORD_INPUT = document.querySelector('#password');
+
+const TEST_EMAIL = 'test@codeit.com';
+const TEST_PW = 'codeit101';
+
+// 인풋 입력 에러 시
+function inputError(e, message) {
+    e.target.classList.add('input-error');
+    
+    const SPAN = document.createElement('span');
+    SPAN.classList.add('input-error-text');
+    SPAN.textContent = message;
+    e.target.after(SPAN);
+}
+
+export { EMAIL_INPUT, PASSWORD_INPUT, TEST_EMAIL, TEST_PW, inputError };

--- a/signin/index.html
+++ b/signin/index.html
@@ -32,6 +32,6 @@
                 </div>
             </div>
         </form> 
-        <script src="./index.js"></script>
+        <script type="module" src="./index.js"></script>
     </body>
 </html>

--- a/signin/index.js
+++ b/signin/index.js
@@ -1,28 +1,28 @@
-const emailInput = document.querySelector('#email');
-const passwordInput = document.querySelector('#password');
-const loginBtn = document.querySelector('button.login');
+const EMAIL_INPUT = document.querySelector('#email');
+const PASSWORD_INPUT = document.querySelector('#password');
+const LOGIN_BTN = document.querySelector('button.login');
 
-const testEmail = 'test@codeit.com';
-const testPw = 'codeit101';
+const TEST_EMAIL = 'test@codeit.com';
+const TEST_PW = 'codeit101';
 
 // 인풋 입력 에러 시
 function inputError(e, message) {
     e.target.classList.add('input-error');
     
-    const span = document.createElement('span');
-    span.classList.add('input-error-text');
-    span.textContent = message;
-    e.target.after(span);
+    const SPAN = document.createElement('span');
+    SPAN.classList.add('input-error-text');
+    SPAN.textContent = message;
+    e.target.after(SPAN);
 }
 
 // 로그인 실패 시 메세지
 function loginError(element, message) {
     element.classList.add('input-error');
     
-    const span = document.createElement('span');
-    span.classList.add('input-error-text');
-    span.textContent = message;
-    element.after(span);
+    const SPAN = document.createElement('span');
+    SPAN.classList.add('input-error-text');
+    SPAN.textContent = message;
+    element.after(SPAN);
 
     if (element.nextElementSibling.nextElementSibling.tagName === 'SPAN') {
         element.nextElementSibling.nextElementSibling.remove();
@@ -31,20 +31,20 @@ function loginError(element, message) {
 
 // 이메일 인풋 검사
 function emailChecker(e) {
-    if (!emailInput.value) {
-        const enterEmail = "이메일을 입력해 주세요."
-        inputError(e, enterEmail);
-    } else if (emailInput.validity.typeMismatch) {
-        const notAnEmail = "올바른 이메일 주소가 아닙니다."
-        inputError(e, notAnEmail);
+    if (!EMAIL_INPUT.value) {
+        const ENTER_EMAIL = "이메일을 입력해 주세요."
+        inputError(e, ENTER_EMAIL);
+    } else if (EMAIL_INPUT.validity.typeMismatch) {
+        const NOT_AN_EMAIL = "올바른 이메일 주소가 아닙니다."
+        inputError(e, NOT_AN_EMAIL);
     }
 }
 
 // 비밀번호 인풋 검사
 function passwordChecker(e) {
-    if (!passwordInput.value) {
-        const enterPassword = "비밀번호를 입력해 주세요."
-        inputError(e, enterPassword);
+    if (!PASSWORD_INPUT.value) {
+        const ENTER_PW = "비밀번호를 입력해 주세요."
+        inputError(e, ENTER_PW);
     } 
 }
 
@@ -58,23 +58,23 @@ function removeError(e) {
 
 // 로그인 검사
 function signInChecker(e) {
-        if (emailInput.value === testEmail && passwordInput.value === testPw) {
+        if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
             location.replace('/folder');
         } else {
-            const checkYourEmail = '이메일을 확인해 주세요.';
-            const checkYourPassword = '비밀번호를 확인해 주세요.';
+            const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
+            const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
 
-            loginError(emailInput, checkYourEmail);
-            loginError(passwordInput, checkYourPassword);
+            loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
+            loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
         }
 }
 
-emailInput.addEventListener('focusout', emailChecker);
-emailInput.addEventListener('focusin', removeError);
-passwordInput.addEventListener('focusout', passwordChecker);
-passwordInput.addEventListener('focusin', removeError);
+EMAIL_INPUT.addEventListener('focusout', emailChecker);
+EMAIL_INPUT.addEventListener('focusin', removeError);
+PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
+PASSWORD_INPUT.addEventListener('focusin', removeError);
 
-loginBtn.addEventListener('click', signInChecker);
+LOGIN_BTN.addEventListener('click', signInChecker);
 
 
 

--- a/signin/index.js
+++ b/signin/index.js
@@ -50,7 +50,7 @@ function signInChecker(e) {
     }
 
     if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
-        location.replace('/folder');
+        location.assign('/folder');
     } else {
         const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
         const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';

--- a/signin/index.js
+++ b/signin/index.js
@@ -45,15 +45,19 @@ function removeError(e) {
 
 // 로그인 검사
 function signInChecker(e) {
-        if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
-            location.replace('/folder');
-        } else {
-            const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
-            const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+    if (e.type === 'keydown' && e.key !== 'Enter') {
+        return;
+    }
 
-            loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
-            loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
-        }
+    if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
+        location.replace('/folder');
+    } else {
+        const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
+        const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+
+        loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
+        loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
+    }
 }
 
 EMAIL_INPUT.addEventListener('focusout', emailChecker);
@@ -62,6 +66,7 @@ PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
 PASSWORD_INPUT.addEventListener('focusin', removeError);
 
 LOGIN_BTN.addEventListener('click', signInChecker);
+document.querySelector('body').addEventListener('keydown', signInChecker);
 
 
 

--- a/signup/index.html
+++ b/signup/index.html
@@ -34,5 +34,6 @@
             </div>
         </div>
     </form>
+    <script type="module" src="./index.js"></script>
 </body>
 </html>

--- a/signup/index.html
+++ b/signup/index.html
@@ -19,7 +19,7 @@
         <input id="password" name="password" type="password">
         <label for="password-check">비밀번호 확인</label>
         <input id="password-check" name="password-check" type="password">
-        <button class="signup">회원가입</button>
+        <button class="signup" type="button">회원가입</button>
         <div class="sns-box">
             <div class="sns-login">
                 소셜 로그인

--- a/signup/index.js
+++ b/signup/index.js
@@ -72,6 +72,7 @@ function signUpChecker(e) {
 
     const INVALID_EMAIL = !EMAIL_INPUT.value || EMAIL_INPUT.validity.typeMismatch || EMAIL_INPUT.value === TEST_EMAIL;
     const INVALID_PW = PASSWORD_INPUT.value.length < 8 || Boolean(PASSWORD_INPUT.value / 1) || PASSWORD_INPUT.value / 1 === 0 || pwCopy.every(element => !(element / 1));
+    const INVALID_PW_REPEAT = PASSWORD_INPUT.value !== PW_REPEAT_INPUT.value;
 
     if (INVALID_EMAIL) {
         const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
@@ -83,7 +84,12 @@ function signUpChecker(e) {
         loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
     } 
 
-    if (!INVALID_EMAIL && !INVALID_PW) {
+    if (INVALID_PW_REPEAT) {
+        const CHECK_YOUR_PW = '비밀번호가 일치하지 않아요.';
+        loginError(PW_REPEAT_INPUT, CHECK_YOUR_PW);
+    } 
+
+    if (!INVALID_EMAIL && !INVALID_PW && !INVALID_PW_REPEAT) {
         location.replace('/folder');
     }
 }   
@@ -95,4 +101,3 @@ PASSWORD_INPUT.addEventListener('focusin', removeError);
 PW_REPEAT_INPUT.addEventListener('keyup', passwordRepeatChecker);
 
 SIGNUP_BTN.addEventListener('click', signUpChecker);
-

--- a/signup/index.js
+++ b/signup/index.js
@@ -45,7 +45,7 @@ function passwordChecker(e) {
 }
 
 // 비밀번호확인란 검사
-function passwordRepeatChecker(e) {
+function passwordRepeatChecker(e) {    
     const PW_NOT_SAME = "비밀번호가 일치하지 않아요.";
 
     if (PW_REPEAT_INPUT.nextElementSibling.classList.contains('input-error-text')) {
@@ -67,6 +67,10 @@ function removeError(e) {
 
 // 회원가입 검사
 function signUpChecker(e) {
+    if (e.type === 'keydown' && e.key !== 'Enter') {
+        return;
+    }
+
     let pwCopy = PASSWORD_INPUT.value;
     pwCopy = [...pwCopy];
 
@@ -101,3 +105,4 @@ PASSWORD_INPUT.addEventListener('focusin', removeError);
 PW_REPEAT_INPUT.addEventListener('keyup', passwordRepeatChecker);
 
 SIGNUP_BTN.addEventListener('click', signUpChecker);
+document.querySelector('body').addEventListener('keydown', signUpChecker);

--- a/signup/index.js
+++ b/signup/index.js
@@ -1,6 +1,6 @@
 import { EMAIL_INPUT, PASSWORD_INPUT, TEST_EMAIL, TEST_PW, inputError } from '../common.js';
 
-const LOGIN_BTN = document.querySelector('button.login');
+const SIGNUP_BTN = document.querySelector('button.signup');
 
 // 로그인 실패 시 메세지
 function loginError(element, message) {
@@ -61,7 +61,7 @@ EMAIL_INPUT.addEventListener('focusin', removeError);
 PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
 PASSWORD_INPUT.addEventListener('focusin', removeError);
 
-LOGIN_BTN.addEventListener('click', signInChecker);
+SIGNUP_BTN.addEventListener('click', signInChecker);
 
 
 

--- a/signup/index.js
+++ b/signup/index.js
@@ -22,17 +22,13 @@ function emailChecker(e) {
     if (!EMAIL_INPUT.value) {
         const ENTER_EMAIL = "이메일을 입력해 주세요."
         inputError(e, ENTER_EMAIL);
-    } 
-    
-    if (EMAIL_INPUT.validity.typeMismatch) {
+    } else if (EMAIL_INPUT.validity.typeMismatch) {
         const NOT_AN_EMAIL = "올바른 이메일 주소가 아닙니다."
         inputError(e, NOT_AN_EMAIL);
-    }
-    
-    if (EMAIL_INPUT.value === TEST_EMAIL) {
+    } else if (EMAIL_INPUT.value === TEST_EMAIL) {
         const EXISTING_EMAIL = "이미 사용 중인 이메일입니다.";
         inputError(e, EXISTING_EMAIL);
-    }
+    } 
 }
 
 // 비밀번호 인풋 검사
@@ -69,18 +65,28 @@ function removeError(e) {
     }
 }
 
-// 로그인 검사
-function signInChecker(e) {
-        if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
-            location.replace('/folder');
-        } else {
-            const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
-            const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+// 회원가입 검사
+function signUpChecker(e) {
+    let pwCopy = PASSWORD_INPUT.value;
+    pwCopy = [...pwCopy];
 
-            loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
-            loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
-        }
-}
+    const INVALID_EMAIL = !EMAIL_INPUT.value || EMAIL_INPUT.validity.typeMismatch || EMAIL_INPUT.value === TEST_EMAIL;
+    const INVALID_PW = PASSWORD_INPUT.value.length < 8 || Boolean(PASSWORD_INPUT.value / 1) || PASSWORD_INPUT.value / 1 === 0 || pwCopy.every(element => !(element / 1));
+
+    if (INVALID_EMAIL) {
+        const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
+        loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
+    } 
+    
+    if (INVALID_PW) {
+        const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+        loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
+    } 
+
+    if (!INVALID_EMAIL && !INVALID_PW) {
+        location.replace('/folder');
+    }
+}   
 
 EMAIL_INPUT.addEventListener('focusout', emailChecker);
 EMAIL_INPUT.addEventListener('focusin', removeError);
@@ -88,5 +94,5 @@ PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
 PASSWORD_INPUT.addEventListener('focusin', removeError);
 PW_REPEAT_INPUT.addEventListener('keyup', passwordRepeatChecker);
 
-SIGNUP_BTN.addEventListener('click', signInChecker);
+SIGNUP_BTN.addEventListener('click', signUpChecker);
 

--- a/signup/index.js
+++ b/signup/index.js
@@ -1,6 +1,7 @@
 import { EMAIL_INPUT, PASSWORD_INPUT, TEST_EMAIL, TEST_PW, inputError } from '../common.js';
 
 const SIGNUP_BTN = document.querySelector('button.signup');
+const PW_REPEAT_INPUT = document.querySelector('#password-check')
 
 // 로그인 실패 시 메세지
 function loginError(element, message) {
@@ -47,6 +48,19 @@ function passwordChecker(e) {
     }
 }
 
+// 비밀번호확인란 검사
+function passwordRepeatChecker(e) {
+    const PW_NOT_SAME = "비밀번호가 일치하지 않아요.";
+
+    if (PW_REPEAT_INPUT.nextElementSibling.classList.contains('input-error-text')) {
+        removeError(e);
+    }
+
+    if (PASSWORD_INPUT.value !== PW_REPEAT_INPUT.value) {
+        inputError(e, PW_NOT_SAME);
+    }
+}
+
 // 에러 표시 숨기기
 function removeError(e) {
     if (e.target.nextElementSibling.classList.contains('input-error-text')) {
@@ -72,6 +86,7 @@ EMAIL_INPUT.addEventListener('focusout', emailChecker);
 EMAIL_INPUT.addEventListener('focusin', removeError);
 PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
 PASSWORD_INPUT.addEventListener('focusin', removeError);
+PW_REPEAT_INPUT.addEventListener('keyup', passwordRepeatChecker);
 
 SIGNUP_BTN.addEventListener('click', signInChecker);
 

--- a/signup/index.js
+++ b/signup/index.js
@@ -21,18 +21,30 @@ function emailChecker(e) {
     if (!EMAIL_INPUT.value) {
         const ENTER_EMAIL = "이메일을 입력해 주세요."
         inputError(e, ENTER_EMAIL);
-    } else if (EMAIL_INPUT.validity.typeMismatch) {
+    } 
+    
+    if (EMAIL_INPUT.validity.typeMismatch) {
         const NOT_AN_EMAIL = "올바른 이메일 주소가 아닙니다."
         inputError(e, NOT_AN_EMAIL);
+    }
+    
+    if (EMAIL_INPUT.value === TEST_EMAIL) {
+        const EXISTING_EMAIL = "이미 사용 중인 이메일입니다.";
+        inputError(e, EXISTING_EMAIL);
     }
 }
 
 // 비밀번호 인풋 검사
 function passwordChecker(e) {
-    if (!PASSWORD_INPUT.value) {
-        const ENTER_PW = "비밀번호를 입력해 주세요."
-        inputError(e, ENTER_PW);
-    } 
+    const PW_REQUIREMENT = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    let pwCopy = PASSWORD_INPUT.value;
+    pwCopy = [...pwCopy];
+
+    if (PASSWORD_INPUT.value.length < 8 || Boolean(PASSWORD_INPUT.value / 1) || PASSWORD_INPUT.value / 1 === 0) {
+        inputError(e, PW_REQUIREMENT);
+    } else if (pwCopy.every(element => !(element / 1))) {
+        inputError(e, PW_REQUIREMENT);
+    }
 }
 
 // 에러 표시 숨기기
@@ -62,6 +74,4 @@ PASSWORD_INPUT.addEventListener('focusout', passwordChecker);
 PASSWORD_INPUT.addEventListener('focusin', removeError);
 
 SIGNUP_BTN.addEventListener('click', signInChecker);
-
-
 

--- a/signup/index.js
+++ b/signup/index.js
@@ -94,7 +94,7 @@ function signUpChecker(e) {
     } 
 
     if (!INVALID_EMAIL && !INVALID_PW && !INVALID_PW_REPEAT) {
-        location.replace('/folder');
+        location.assign('/folder');
     }
 }   
 

--- a/signup/style.css
+++ b/signup/style.css
@@ -50,8 +50,20 @@ a.login {
     border: 1px solid #6D6AFE; 
 }
 
-.signin input#password {
+/* .signin input#password {
     margin-bottom: 32px;
+} */
+
+.signin .input-error {
+    border: 1px solid #ff5b56;
+    margin-bottom: 6px;
+}
+
+.input-error-text {
+    display: inline-block;
+    color: #ff5b56;
+    font-size: 14px;
+    margin-bottom: 6px;
 }
 
 .signup {


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x]  [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x]  [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x]  [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x]  [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [ ]  [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ]  [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ]  [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 회원가입 조건 검사 기능 추가


## 스크린샷


## 멘토에게

- netlify 주소입니다: https://stirring-seahorse-43f42f.netlify.app/
- 로그인이랑 회원가입 페이지에서 테스트 id, pw 로 가입 후 /folder로 이동했다가 뒤로가기를 누르면 이메일에 입력한 값이 그대로 남겨져 있는데 어떻게 없어지게 해야 할까요????
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
