### PR TITLE
[안연아]Week5

### DIFF
--- a/signin.html
+++ b/signin.html
@@ -44,7 +44,7 @@
       </div>
     </div>
   </div>
-  <script src="signin.js"></script>
+  <script type="module" src="signin.js"></script>
 </body>
 
 

--- a/signin.js
+++ b/signin.js
@@ -34,17 +34,17 @@ function handleBlur(input, message) {
   }
 }
 
-//눈 모양 아이콘 이벤트
-document.querySelector(".eye-button").addEventListener("click", function () {
-  toggleEye(passwordInput);
-});
-
 emailInput.addEventListener("blur", function () {
   handleBlur(emailInput, getNewMessageElement("이메일을 입력해 주세요."));
 });
 
 passwordInput.addEventListener("blur", function () {
   handleBlur(passwordInput, getNewMessageElement("비밀번호를 입력해 주세요."));
+});
+
+//눈 모양 아이콘 이벤트
+document.querySelector(".eye-button").addEventListener("click", function () {
+  toggleEye(passwordInput);
 });
 
 function signIn(event) {

--- a/signin.js
+++ b/signin.js
@@ -1,12 +1,13 @@
-import { emailRegex, getNewMessageElement, toggleEye } from "./utils.js";
+import {
+  emailRegex,
+  emailValidChk,
+  getNewMessageElement,
+  toggleEye,
+} from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const loginButton = document.getElementById("loginButton");
-
-function emailValidChk(email) {
-  return emailRegex.test(email);
-}
 
 function handleBlur(input, message) {
   const messageContainer = input.parentElement;

--- a/signin.js
+++ b/signin.js
@@ -1,3 +1,5 @@
+import { toggleEye } from "./utils.js";
+
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const loginButton = document.getElementById("loginButton");
@@ -39,19 +41,9 @@ function handleBlur(input, message) {
 }
 
 //눈 모양 아이콘 이벤트
-const toggleEye = () => {
-  const eyeOff = "/images/eye-off.svg";
-  const eyeOn = "/images/eye-on.svg";
-  const passwordInput = document.getElementById("passwordInput");
-
-  if (passwordInput.type === "password") {
-    passwordInput.type = "text";
-    document.querySelector(".eye-button").src = eyeOn;
-  } else {
-    passwordInput.type = "password";
-    document.querySelector(".eye-button").src = eyeOff;
-  }
-};
+document.querySelector(".eye-button").addEventListener("click", function () {
+  toggleEye(passwordInput);
+});
 
 emailInput.addEventListener("blur", function () {
   handleBlur(emailInput, createMessage("이메일을 입력해 주세요."));
@@ -60,8 +52,6 @@ emailInput.addEventListener("blur", function () {
 passwordInput.addEventListener("blur", function () {
   handleBlur(passwordInput, createMessage("비밀번호를 입력해 주세요."));
 });
-
-document.querySelector(".eye-button").addEventListener("click", toggleEye);
 
 function signIn(event) {
   const email = emailInput.value.trim();

--- a/signin.js
+++ b/signin.js
@@ -1,16 +1,9 @@
-import { toggleEye } from "./utils.js";
+import { getNewMessageElement, toggleEye } from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const loginButton = document.getElementById("loginButton");
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
-
-function createMessage(message) {
-  const messageElement = document.createElement("p");
-  messageElement.textContent = message;
-  messageElement.classList.add("empty-message");
-  return messageElement;
-}
 
 function emailValidChk(email) {
   return emailRegex.test(email);
@@ -33,7 +26,8 @@ function handleBlur(input, message) {
 
     // 이메일 유효성 검사
     if (input === emailInput && !emailValidChk(input.value)) {
-      const emailMessage = createMessage("올바른 이메일 주소가 아닙니다.");
+      const emailMessage =
+        getNewMessageElement("올바른 이메일 주소가 아닙니다.");
       messageContainer.appendChild(emailMessage);
       input.classList.add("empty-input");
     }
@@ -46,11 +40,11 @@ document.querySelector(".eye-button").addEventListener("click", function () {
 });
 
 emailInput.addEventListener("blur", function () {
-  handleBlur(emailInput, createMessage("이메일을 입력해 주세요."));
+  handleBlur(emailInput, getNewMessageElement("이메일을 입력해 주세요."));
 });
 
 passwordInput.addEventListener("blur", function () {
-  handleBlur(passwordInput, createMessage("비밀번호를 입력해 주세요."));
+  handleBlur(passwordInput, getNewMessageElement("비밀번호를 입력해 주세요."));
 });
 
 function signIn(event) {
@@ -79,13 +73,13 @@ function signIn(event) {
   } else {
     // 로그인 실패 - 에러 메시지 표시
     if (email !== "test@codeit.com") {
-      const emailMessage = createMessage("이메일을 확인해 주세요.");
+      const emailMessage = getNewMessageElement("이메일을 확인해 주세요.");
       const parentElement = document.querySelector(".sign-input-box");
       parentElement.appendChild(emailMessage);
     }
 
     if (password !== "codeit101") {
-      const passwordMessage = createMessage("비밀번호를 확인해 주세요.");
+      const passwordMessage = getNewMessageElement("비밀번호를 확인해 주세요.");
       const parentElement = document.querySelector(".sign-password");
       parentElement.appendChild(passwordMessage);
     }

--- a/signin.js
+++ b/signin.js
@@ -1,9 +1,8 @@
-import { getNewMessageElement, toggleEye } from "./utils.js";
+import { emailRegex, getNewMessageElement, toggleEye } from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const loginButton = document.getElementById("loginButton");
-const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
 function emailValidChk(email) {
   return emailRegex.test(email);

--- a/signup.html
+++ b/signup.html
@@ -35,7 +35,7 @@
           <img class="eye-button-check" src="./images/eye-off.svg" />
         </div>
       </div>
-      <button class="cta" type="submit">회원가입</button>
+      <div class="cta" id="loginButton">회원가입</div>
     </form>
     <div class="sns-box">
       <span class="sns-text">다른 방식으로 가입하기</span>

--- a/signup.html
+++ b/signup.html
@@ -27,12 +27,12 @@
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호</label>
           <input class="sign-input" type="password" id="passwordInput" />
-          <img class="eye-button" src="/images/eye-off.svg" />
+          <img class="eye-button" src="./images/eye-off.svg" />
         </div>
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호 확인</label>
           <input class="sign-input" type="password" id="passwordCheck" />
-          <img class="eye-button-check" src="/images/eye-off.svg" />
+          <img class="eye-button-check" src="./images/eye-off.svg" />
         </div>
       </div>
       <button class="cta" type="submit">회원가입</button>

--- a/signup.html
+++ b/signup.html
@@ -49,7 +49,8 @@
       </div>
     </div>
   </div>
-  <script src="signup.js"></script>
+  <script type="module" src="signup.js"></script>
+
 </body>
 
 </html>

--- a/signup.html
+++ b/signup.html
@@ -22,21 +22,19 @@
       <div class="sign-inputs">
         <div class="sign-input-box">
           <label class="sign-input-label">이메일</label>
-          <input class="sign-input" />
+          <input class="sign-input" id="emailInput">
         </div>
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호</label>
-          <input class="sign-input" type="password" />
-          <button class="eye-button" type="button">
-            <img src="./images/eye-off.svg" />
-          </button>
+          <input class="sign-input" type="password" id="passwordInput" />
+          <img class="eye-button" src="./images/eye-off.svg" />
         </div>
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호 확인</label>
-          <input class="sign-input" type="password" />
-          <button class="eye-button" type="button">
-            <img src="./images/eye-off.svg" />
-          </button>
+          <input class="sign-input" type="password" id="passwordCheck" />
+
+          <img class="eye-button" src="./images/eye-off.svg" />
+
         </div>
       </div>
       <button class="cta" type="submit">회원가입</button>
@@ -53,7 +51,7 @@
       </div>
     </div>
   </div>
-
+  <script src="signup.js"></script>
 </body>
 
 </html>

--- a/signup.html
+++ b/signup.html
@@ -27,14 +27,12 @@
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호</label>
           <input class="sign-input" type="password" id="passwordInput" />
-          <img class="eye-button" src="./images/eye-off.svg" />
+          <img class="eye-button" src="/images/eye-off.svg" />
         </div>
         <div class="sign-input-box sign-password">
           <label class="sign-input-label">비밀번호 확인</label>
           <input class="sign-input" type="password" id="passwordCheck" />
-
-          <img class="eye-button" src="./images/eye-off.svg" />
-
+          <img class="eye-button-check" src="/images/eye-off.svg" />
         </div>
       </div>
       <button class="cta" type="submit">회원가입</button>

--- a/signup.js
+++ b/signup.js
@@ -49,6 +49,13 @@ function handleBlur(input, message) {
       messageContainer.appendChild(message);
       input.classList.add("empty-input");
     }
+    // 이메일 중복 확인 조건을 수행하고 그에 따라 에러 메시지 추가
+    if (input === emailInput && input.value === "test@codeit.com") {
+      const duplicateEmailMessage =
+        createMessage("이미 사용 중인 이메일입니다.");
+      messageContainer.appendChild(duplicateEmailMessage);
+      input.classList.add("empty-input");
+    }
   }
 }
 

--- a/signup.js
+++ b/signup.js
@@ -1,3 +1,5 @@
+import { toggleEye } from "./utils.js";
+
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const passwordCheck = document.getElementById("passwordCheck");
@@ -74,27 +76,14 @@ passwordInput.addEventListener("blur", function () {
 });
 
 //눈 모양 아이콘 이벤트
-const toggleEye = (input) => {
-  const eyeOff = "/images/eye-off.svg";
-  const eyeOn = "/images/eye-on.svg";
-
-  if (input.type === "password") {
-    input.type = "text";
-    input.nextElementSibling.src = eyeOn;
-  } else {
-    input.type = "password";
-    input.nextElementSibling.src = eyeOff;
-  }
-};
-
 document.querySelector(".eye-button").addEventListener("click", function () {
-  toggleEye(document.getElementById("passwordInput"));
+  toggleEye(passwordInput);
 });
 
 document
   .querySelector(".eye-button-check")
   .addEventListener("click", function () {
-    toggleEye(document.getElementById("passwordCheck"));
+    toggleEye(passwordCheck);
   });
 
 //비밀번호 일치 확인

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,41 @@
+const emailInput = document.getElementById("emailInput");
+const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+function createMessage(message) {
+  const messageElement = document.createElement("p");
+  messageElement.textContent = message;
+  messageElement.classList.add("empty-message");
+  return messageElement;
+}
+
+function emailValidChk(email) {
+  return emailRegex.test(email);
+}
+
+function handleBlur(input, message) {
+  const messageContainer = input.parentElement;
+  const existingMessage = messageContainer.querySelector("p");
+
+  if (input.value.trim() === "") {
+    if (!existingMessage) {
+      messageContainer.appendChild(message);
+    }
+    input.classList.add("empty-input");
+  } else {
+    if (existingMessage) {
+      existingMessage.remove();
+    }
+    input.classList.remove("empty-input");
+
+    // 이메일 유효성 검사
+    if (input === emailInput && !emailValidChk(input.value)) {
+      const emailMessage = createMessage("올바른 이메일 주소가 아닙니다.");
+      messageContainer.appendChild(emailMessage);
+      input.classList.add("empty-input");
+    }
+  }
+}
+
+emailInput.addEventListener("blur", function () {
+  handleBlur(emailInput, createMessage("이메일을 입력해 주세요."));
+});

--- a/signup.js
+++ b/signup.js
@@ -95,3 +95,28 @@ document
   .addEventListener("click", function () {
     toggleEye(document.getElementById("passwordCheck"));
   });
+
+//비밀번호 일치 확인
+function handlePasswordCheck() {
+  const password1 = passwordInput.value;
+  const password2 = passwordCheck.value;
+  const messageContainer = passwordCheck.parentElement;
+  const existingMessage = messageContainer.querySelector("p");
+
+  if (password1 !== password2) {
+    const passwordMismatchMessage =
+      createMessage("비밀번호가 일치하지 않아요.");
+
+    if (!existingMessage) {
+      messageContainer.appendChild(passwordMismatchMessage);
+    }
+    passwordCheck.classList.add("empty-input");
+  } else {
+    if (existingMessage) {
+      existingMessage.remove();
+    }
+    passwordCheck.classList.remove("empty-input");
+  }
+}
+
+passwordCheck.addEventListener("blur", handlePasswordCheck);

--- a/signup.js
+++ b/signup.js
@@ -1,5 +1,7 @@
 const emailInput = document.getElementById("emailInput");
+const passwordInput = document.getElementById("passwordInput");
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
 
 function createMessage(message) {
   const messageElement = document.createElement("p");
@@ -12,30 +14,52 @@ function emailValidChk(email) {
   return emailRegex.test(email);
 }
 
+function passwordValidChk(password) {
+  return passwordRegex.test(password);
+}
+
 function handleBlur(input, message) {
   const messageContainer = input.parentElement;
   const existingMessage = messageContainer.querySelector("p");
 
   if (input.value.trim() === "") {
+    // 입력 값이 비어있는 경우
     if (!existingMessage) {
+      // 에러 메시지가 이미 존재하지 않는 경우에만 메시지를 추가
       messageContainer.appendChild(message);
     }
     input.classList.add("empty-input");
   } else {
     if (existingMessage) {
+      // 입력 값이 비어있지 않은 경우 에러 메시지가 이미 존재하면 제거
       existingMessage.remove();
     }
     input.classList.remove("empty-input");
 
-    // 이메일 유효성 검사
-    if (input === emailInput && !emailValidChk(input.value)) {
-      const emailMessage = createMessage("올바른 이메일 주소가 아닙니다.");
-      messageContainer.appendChild(emailMessage);
+    // 유효성 검사 조건을 수행하고 그에 따라 에러 메시지 추가
+    if (
+      (input === emailInput && !emailValidChk(input.value)) ||
+      (input === passwordInput &&
+        (!passwordValidChk(input.value) ||
+          input.value.length < 8 ||
+          !/\d/.test(input.value) ||
+          !/[a-zA-Z]/.test(input.value)))
+    ) {
+      messageContainer.appendChild(message);
       input.classList.add("empty-input");
     }
   }
 }
 
 emailInput.addEventListener("blur", function () {
+  // 이메일 입력란에 포커스를 잃었을 때의 처리
   handleBlur(emailInput, createMessage("이메일을 입력해 주세요."));
+});
+
+passwordInput.addEventListener("blur", function () {
+  // 비밀번호 입력란에 포커스를 잃었을 때의 처리
+  const passwordMessage = createMessage(
+    "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+  );
+  handleBlur(passwordInput, passwordMessage);
 });

--- a/signup.js
+++ b/signup.js
@@ -72,10 +72,10 @@ const toggleEye = (input) => {
 
   if (input.type === "password") {
     input.type = "text";
-    input.nextElementSibling.src = eyeOn; // 다음 형제 요소의 이미지를 변경
+    input.nextElementSibling.src = eyeOn;
   } else {
     input.type = "password";
-    input.nextElementSibling.src = eyeOff; // 다음 형제 요소의 이미지를 변경
+    input.nextElementSibling.src = eyeOff;
   }
 };
 

--- a/signup.js
+++ b/signup.js
@@ -1,10 +1,9 @@
-import { getNewMessageElement, toggleEye } from "./utils.js";
+import { emailRegex, getNewMessageElement, toggleEye } from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const passwordCheck = document.getElementById("passwordCheck");
 const loginButton = document.getElementById("loginButton");
-const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
 
 function emailValidChk(email) {

--- a/signup.js
+++ b/signup.js
@@ -1,14 +1,15 @@
-import { emailRegex, getNewMessageElement, toggleEye } from "./utils.js";
+import {
+  emailRegex,
+  emailValidChk,
+  getNewMessageElement,
+  toggleEye,
+} from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const passwordCheck = document.getElementById("passwordCheck");
 const loginButton = document.getElementById("loginButton");
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
-
-function emailValidChk(email) {
-  return emailRegex.test(email);
-}
 
 function passwordValidChk(password) {
   return passwordRegex.test(password);

--- a/signup.js
+++ b/signup.js
@@ -1,4 +1,4 @@
-import { toggleEye } from "./utils.js";
+import { getNewMessageElement, toggleEye } from "./utils.js";
 
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
@@ -6,13 +6,6 @@ const passwordCheck = document.getElementById("passwordCheck");
 const loginButton = document.getElementById("loginButton");
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
-
-function createMessage(message) {
-  const messageElement = document.createElement("p");
-  messageElement.textContent = message;
-  messageElement.classList.add("empty-message");
-  return messageElement;
-}
 
 function emailValidChk(email) {
   return emailRegex.test(email);
@@ -55,7 +48,7 @@ function handleBlur(input, message) {
     // 이메일 중복 확인 조건을 수행하고 그에 따라 에러 메시지 추가
     if (input === emailInput && input.value === "test@codeit.com") {
       const duplicateEmailMessage =
-        createMessage("이미 사용 중인 이메일입니다.");
+        getNewMessageElement("이미 사용 중인 이메일입니다.");
       messageContainer.appendChild(duplicateEmailMessage);
       input.classList.add("empty-input");
     }
@@ -64,18 +57,18 @@ function handleBlur(input, message) {
 
 emailInput.addEventListener("blur", function () {
   // 이메일 입력란에 포커스를 잃었을 때의 처리
-  handleBlur(emailInput, createMessage("이메일을 입력해 주세요."));
+  handleBlur(emailInput, getNewMessageElement("이메일을 입력해 주세요."));
 });
 
 passwordInput.addEventListener("blur", function () {
   // 비밀번호 입력란에 포커스를 잃었을 때의 처리
-  const passwordMessage = createMessage(
+  const passwordMessage = getNewMessageElement(
     "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
   );
   handleBlur(passwordInput, passwordMessage);
 });
 
-//눈 모양 아이콘 이벤트
+//눈 모양 이벤트
 document.querySelector(".eye-button").addEventListener("click", function () {
   toggleEye(passwordInput);
 });
@@ -95,7 +88,7 @@ function handlePasswordCheck() {
 
   if (password1 !== password2) {
     const passwordMismatchMessage =
-      createMessage("비밀번호가 일치하지 않아요.");
+      getNewMessageElement("비밀번호가 일치하지 않아요.");
 
     if (!existingMessage) {
       messageContainer.appendChild(passwordMismatchMessage);

--- a/signup.js
+++ b/signup.js
@@ -1,6 +1,7 @@
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
 const passwordCheck = document.getElementById("passwordCheck");
+const loginButton = document.getElementById("loginButton");
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
 
@@ -120,3 +121,44 @@ function handlePasswordCheck() {
 }
 
 passwordCheck.addEventListener("blur", handlePasswordCheck);
+
+// 회원가입 시도
+function signUp(event) {
+  event.preventDefault();
+
+  const email = emailInput.value.trim();
+  const password = passwordInput.value.trim();
+  const passwordCheckValue = passwordCheck.value.trim();
+
+  const emailContainer = emailInput.parentElement;
+  const passwordContainer = passwordInput.parentElement;
+  const passwordCheckContainer = passwordCheck.parentElement;
+
+  const existingEmailMessage = emailContainer.querySelector(".empty-message");
+  const existingPasswordMessage =
+    passwordContainer.querySelector(".empty-message");
+  const existingPasswordCheckMessage =
+    passwordCheckContainer.querySelector(".empty-message");
+
+  // 에러 메시지가 하나라도 있으면 이동하지 않음
+  if (
+    existingEmailMessage ||
+    existingPasswordMessage ||
+    existingPasswordCheckMessage
+  ) {
+    return;
+  }
+
+  // 모든 유효성 검사 통과 시
+  window.location.href = "/folder.html";
+}
+
+// 로그인 버튼 클릭 시 signUp 함수 호출
+loginButton.addEventListener("click", signUp);
+
+// Enter 키 눌렀을 때 signUp 함수 호출
+document.addEventListener("keydown", function (event) {
+  if (event.key === "Enter") {
+    signUp(event);
+  }
+});

--- a/signup.js
+++ b/signup.js
@@ -1,5 +1,6 @@
 const emailInput = document.getElementById("emailInput");
 const passwordInput = document.getElementById("passwordInput");
+const passwordCheck = document.getElementById("passwordCheck");
 const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d).{8,}$/;
 
@@ -63,3 +64,27 @@ passwordInput.addEventListener("blur", function () {
   );
   handleBlur(passwordInput, passwordMessage);
 });
+
+//눈 모양 아이콘 이벤트
+const toggleEye = (input) => {
+  const eyeOff = "/images/eye-off.svg";
+  const eyeOn = "/images/eye-on.svg";
+
+  if (input.type === "password") {
+    input.type = "text";
+    input.nextElementSibling.src = eyeOn; // 다음 형제 요소의 이미지를 변경
+  } else {
+    input.type = "password";
+    input.nextElementSibling.src = eyeOff; // 다음 형제 요소의 이미지를 변경
+  }
+};
+
+document.querySelector(".eye-button").addEventListener("click", function () {
+  toggleEye(document.getElementById("passwordInput"));
+});
+
+document
+  .querySelector(".eye-button-check")
+  .addEventListener("click", function () {
+    toggleEye(document.getElementById("passwordCheck"));
+  });

--- a/src/sign.css
+++ b/src/sign.css
@@ -92,7 +92,8 @@ header {
   border-color: var(--primary);
 }
 
-.eye-button {
+.eye-button,
+.eye-button-check {
   position: absolute;
   top: 5rem;
   right: 1.5rem;

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,11 @@
+export function getNewMessageElement(message) {
+  const messageElement = document.createElement("p");
+  messageElement.textContent = message;
+  messageElement.classList.add("empty-message");
+  return messageElement;
+}
+
+//눈 모양 아이콘 이벤트
 export const toggleEye = (input) => {
   const eyeOff = "/images/eye-off.svg";
   const eyeOn = "/images/eye-on.svg";

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,12 @@
+export const toggleEye = (input) => {
+  const eyeOff = "/images/eye-off.svg";
+  const eyeOn = "/images/eye-on.svg";
+
+  if (input.type === "password") {
+    input.type = "text";
+    input.nextElementSibling.src = eyeOn;
+  } else {
+    input.type = "password";
+    input.nextElementSibling.src = eyeOff;
+  }
+};

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,10 @@
 export const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 
+//이메일 유효성 검사
+export function emailValidChk(email) {
+  return emailRegex.test(email);
+}
+
 export function getNewMessageElement(message) {
   const messageElement = document.createElement("p");
   messageElement.textContent = message;

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,5 @@
+export const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
 export function getNewMessageElement(message) {
   const messageElement = document.createElement("p");
   messageElement.textContent = message;


### PR DESCRIPTION
## 요구사항
### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 회원가입 기능 구현을 위한 signup.js 생성
- 회원가입, 로그인 공통 로직 구현을 위한 utils.js 생성
- 
## 스크린샷

netlify로 배포한 사이트 입니다!  https://65b497e8c65a5f5ab36616a5--bucolic-arithmetic-a2a73b.netlify.app/

## 멘토에게

- signin.js 와 singup.js에서 에러 메시지 구현하는 부분인 handleBlur 함수가 공통되는 부분이 있지만 또 공통되지 않는 부분이 있어서 우선 따로따로 구현했는데 이 둘을 어떻게 공통된 로직만 뽑아서 utils.js에 추가해야 할지 잘 모르겠습니다. 
