### PR TITLE
[김재성] week5

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1,3 +1,3 @@
-import sign from './module_sign.js';
+import moduleSign from './module_sign.js';
 
-export { sign };
+export { moduleSign };

--- a/js/common.js
+++ b/js/common.js
@@ -1,39 +1,35 @@
 const EMAIL_PATTERN = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
 
 function emailValidChk(email) {
-    if (EMAIL_PATTERN.test(email) === false) {
-        return false;
-    } else {
-        return true;
-    }
+    return EMAIL_PATTERN.test(email);
 }
-
+function errorBoxToggle() {}
 function errorBoxEnable(el, text) {
-    let errorBox = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
-    errorBox.innerHTML = text;
-    errorBox.style.display = 'block';
+    const ERROR_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
+    ERROR_BOX.textContent = text;
+    ERROR_BOX.style.display = 'block';
     el.classList.add('error-box');
 }
 function errorBoxDisable(el) {
-    let errorBox = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
-    errorBox.innerHTML = '';
-    errorBox.style.display = 'none';
+    const ERROW_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
+    ERROW_BOX.textContent = '';
+    ERROW_BOX.style.display = 'none';
     el.classList.remove('error-box');
 }
 
-function pwdSwitch(arg) {
-    let check = arg.dataset.check;
-    let targetInput = document.querySelector(`#${check}`);
-    let eye = arg.querySelector('img');
-    if (eye.dataset.onoff == 'off') {
-        eye.dataset.onoff = 'on';
-        eye.setAttribute('src', '/images/eye-on.png');
+function passwordSwitch(targetElement) {
+    const CHECK = targetElement.dataset.check;
+    const TARGET_INPUT = document.querySelector(`#${CHECK}`);
+    const EYE = targetElement.querySelector('img');
+    if (EYE.dataset.onoff == 'off') {
+        EYE.dataset.onoff = 'on';
+        EYE.setAttribute('src', '/images/eye-on.png');
 
-        targetInput.setAttribute('type', 'text');
+        TARGET_INPUT.setAttribute('type', 'text');
     } else {
-        eye.dataset.onoff = 'off';
-        eye.setAttribute('src', '/images/eye-off.png');
+        EYE.dataset.onoff = 'off';
+        EYE.setAttribute('src', '/images/eye-off.png');
 
-        targetInput.setAttribute('type', 'password');
+        TARGET_INPUT.setAttribute('type', 'password');
     }
 }

--- a/js/common.js
+++ b/js/common.js
@@ -1,35 +1,3 @@
-const EMAIL_PATTERN = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+import sign from './module_sign.js';
 
-function emailValidChk(email) {
-    return EMAIL_PATTERN.test(email);
-}
-function errorBoxToggle() {}
-function errorBoxEnable(el, text) {
-    const ERROR_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
-    ERROR_BOX.textContent = text;
-    ERROR_BOX.style.display = 'block';
-    el.classList.add('error-box');
-}
-function errorBoxDisable(el) {
-    const ERROW_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
-    ERROW_BOX.textContent = '';
-    ERROW_BOX.style.display = 'none';
-    el.classList.remove('error-box');
-}
-
-function passwordSwitch(targetElement) {
-    const CHECK = targetElement.dataset.check;
-    const TARGET_INPUT = document.querySelector(`#${CHECK}`);
-    const EYE = targetElement.querySelector('img');
-    if (EYE.dataset.onoff == 'off') {
-        EYE.dataset.onoff = 'on';
-        EYE.setAttribute('src', '/images/eye-on.png');
-
-        TARGET_INPUT.setAttribute('type', 'text');
-    } else {
-        EYE.dataset.onoff = 'off';
-        EYE.setAttribute('src', '/images/eye-off.png');
-
-        TARGET_INPUT.setAttribute('type', 'password');
-    }
-}
+export { sign };

--- a/js/module_sign.js
+++ b/js/module_sign.js
@@ -1,12 +1,23 @@
 const EMAIL_PATTERN = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+const PASSWORD_PATTERN = /^(?=.*[A-Za-z])(?=.*\d).{8,}$/; // 규칙 : 영문, 숫자 조합 8자 이상 입력해야한다
+const LOGIN_INFO = {
+    email: 'test@codeit.com',
+    password: 'codeit101',
+};
 
 // 이메일 형식 체크
 function emailValidChk(email) {
-    return EMAIL_PATTERN.test(email);
+    return !EMAIL_PATTERN.test(email);
+}
+// 비밀번호 생성 규칙 검사
+function passwordRoleCheck(value) {
+    console.log(value);
+    return !PASSWORD_PATTERN.test(value);
 }
 // 이벤트 타입에 따른 에러박스 토글
-function errorBoxToggle(event, el, text) {
-    if (event.type == 'focusin') {
+// 에러 메시지가 있으면 활성, 없으면 비활성 분기
+function errorBoxToggle(el, text) {
+    if (!text) {
         errorBoxDisable(el);
     } else {
         errorBoxEnable(el, text);
@@ -45,8 +56,22 @@ function passwordSwitch(targetElement) {
     }
 }
 
+// 비밀번호 - 비밀번호 확인 값 대조
+function passwordConfirm(el) {
+    const PASSWORD = document.querySelector('#password');
+
+    if (PASSWORD.value != el.value) {
+        errorBoxToggle(el, '비밀번호가 다릅니다');
+    } else {
+        errorBoxToggle(el);
+    }
+}
+
 export default {
     emailValidChk,
     errorBoxToggle,
     passwordSwitch,
+    passwordConfirm,
+    passwordRoleCheck,
+    LOGIN_INFO,
 };

--- a/js/module_sign.js
+++ b/js/module_sign.js
@@ -1,0 +1,52 @@
+const EMAIL_PATTERN = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+
+// 이메일 형식 체크
+function emailValidChk(email) {
+    return EMAIL_PATTERN.test(email);
+}
+// 이벤트 타입에 따른 에러박스 토글
+function errorBoxToggle(event, el, text) {
+    if (event.type == 'focusin') {
+        errorBoxDisable(el);
+    } else {
+        errorBoxEnable(el, text);
+    }
+}
+// 에러박스 활성화
+function errorBoxEnable(el, text) {
+    const ERROR_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
+    ERROR_BOX.textContent = text;
+    ERROR_BOX.style.display = 'block';
+    el.classList.add('error-box');
+}
+// 에러박스 비활성화
+function errorBoxDisable(el) {
+    const ERROW_BOX = document.querySelector(`[data-target='${el.getAttribute('id')}']`);
+    ERROW_BOX.textContent = '';
+    ERROW_BOX.style.display = 'none';
+    el.classList.remove('error-box');
+}
+
+// 비밀번호 view 여부 switch
+function passwordSwitch(targetElement) {
+    const CHECK = targetElement.dataset.check;
+    const TARGET_INPUT = document.querySelector(`#${CHECK}`);
+    const EYE = targetElement.querySelector('img');
+    if (EYE.dataset.onoff == 'off') {
+        EYE.dataset.onoff = 'on';
+        EYE.setAttribute('src', '/images/eye-on.png');
+
+        TARGET_INPUT.setAttribute('type', 'text');
+    } else {
+        EYE.dataset.onoff = 'off';
+        EYE.setAttribute('src', '/images/eye-off.png');
+
+        TARGET_INPUT.setAttribute('type', 'password');
+    }
+}
+
+export default {
+    emailValidChk,
+    errorBoxToggle,
+    passwordSwitch,
+};

--- a/signin/index.html
+++ b/signin/index.html
@@ -18,13 +18,13 @@
                 <form id="login-form-box" action="/folder" method="post">
                     <div class="input-box">
                         <label for="email">이메일</label>
-                        <input type="text" id="email" class="form-input" />
+                        <input type="text" name="email" id="email" class="form-input" />
                         <div class="error-text"></div>
                     </div>
                     <div class="error-text" data-target="email"></div>
                     <div class="input-box">
                         <label for="password">비밀번호</label>
-                        <input type="password" id="password" class="form-input" />
+                        <input type="password" name="password" id="password" class="form-input" />
                         <div class="icon-box pwd-view" data-check="password">
                             <img src="/images/eye-off.png" alt="off" data-onoff="off" />
                         </div>

--- a/signin/index.html
+++ b/signin/index.html
@@ -49,7 +49,6 @@
                 </div>
             </article>
         </main>
-        <script src="/js/common.js"></script>
-        <script type="text/javascript" src="/signin/js/signin.js"></script>
+        <script type="module" src="/signin/js/signin.js"></script>
     </body>
 </html>

--- a/signin/js/signin.js
+++ b/signin/js/signin.js
@@ -4,7 +4,7 @@ const INPUT_PASSWORD = document.querySelector('#password');
 const FORM = document.querySelector('#login-form-box');
 
 PWD_VIEW.addEventListener('click', function () {
-    pwdSwitch(this);
+    passwordSwitch(this);
 });
 INPUT_EMAIL.addEventListener('focusin', function () {
     errorBoxDisable(this);
@@ -27,14 +27,14 @@ INPUT_PASSWORD.addEventListener('focusout', function () {
 });
 
 FORM.addEventListener('submit', function (e) {
-    let email = this.querySelector('#email');
-    let password = this.querySelector('#password');
+    const EMAIL = this['email'];
+    const PASSWORD = this['password'];
 
-    if (email.value === 'test@codeit.com' && password.value === 'codeit101') {
+    if (EMAIL.value === 'test@codeit.com' && PASSWORD.value === 'codeit101') {
         this.submit();
     } else {
         e.preventDefault();
-        errorBoxEnable(email, '이메일을 확인해 주세요.');
-        errorBoxEnable(password, '비밀번호를 확인해 주세요.');
+        errorBoxEnable(EMAIL, '이메일을 확인해 주세요.');
+        errorBoxEnable(PASSWORD, '비밀번호를 확인해 주세요.');
     }
 });

--- a/signin/js/signin.js
+++ b/signin/js/signin.js
@@ -1,34 +1,30 @@
-import { sign } from '/js/common.js';
+import { moduleSign } from '/js/common.js';
 
 const PWD_VIEW = document.querySelector('.pwd-view');
 const INPUT_EMAIL = document.querySelector('#email');
 const INPUT_PASSWORD = document.querySelector('#password');
 const FORM = document.querySelector('#login-form-box');
-const LOGIN_INFO = {
-    email: 'test@codeit.com',
-    password: 'codeit101',
-};
 
 PWD_VIEW.addEventListener('click', function () {
-    sign.passwordSwitch(this);
+    moduleSign.passwordSwitch(this);
 });
-INPUT_EMAIL.addEventListener('focusin', function (e) {
-    sign.errorBoxToggle(e, this);
+INPUT_EMAIL.addEventListener('focusin', function () {
+    moduleSign.errorBoxToggle(this);
 });
-INPUT_EMAIL.addEventListener('focusout', function (e) {
+INPUT_EMAIL.addEventListener('focusout', function () {
     if (this.value == '') {
-        sign.errorBoxToggle(e, this, '이메일을 입력해 주세요.');
-    } else if (!sign.emailValidChk(this.value)) {
-        sign.errorBoxToggle(e, this, '올바른 이메일 주소가 아닙니다.');
+        moduleSign.errorBoxToggle(this, '이메일을 입력해 주세요.');
+    } else if (moduleSign.emailValidChk(this.value)) {
+        moduleSign.errorBoxToggle(this, '올바른 이메일 주소가 아닙니다.');
     }
 });
 
-INPUT_PASSWORD.addEventListener('focusin', function (e) {
-    sign.errorBoxToggle(e, this);
+INPUT_PASSWORD.addEventListener('focusin', function () {
+    moduleSign.errorBoxToggle(this);
 });
-INPUT_PASSWORD.addEventListener('focusout', function (e) {
+INPUT_PASSWORD.addEventListener('focusout', function () {
     if (this.value == '') {
-        sign.errorBoxToggle(e, this, '비밀번호를 입력해 주세요.');
+        moduleSign.errorBoxToggle(this, '비밀번호를 입력해 주세요.');
     }
 });
 
@@ -37,11 +33,11 @@ FORM.addEventListener('submit', function (e) {
     const PASSWORD = this['password'];
 
     // 로그인 정보 대조 후 submit
-    if (EMAIL.value === LOGIN_INFO.email && PASSWORD.value === LOGIN_INFO.password) {
+    if (EMAIL.value === moduleSign.LOGIN_INFO.email && PASSWORD.value === moduleSign.LOGIN_INFO.password) {
         this.submit();
     } else {
         e.preventDefault();
-        sign.errorBoxToggle(e, EMAIL, '이메일을 확인해 주세요.');
-        sign.errorBoxToggle(e, PASSWORD, '비밀번호를 확인해 주세요.');
+        moduleSign.errorBoxToggle(EMAIL, '이메일을 확인해 주세요.');
+        moduleSign.errorBoxToggle(PASSWORD, '비밀번호를 확인해 주세요.');
     }
 });

--- a/signin/js/signin.js
+++ b/signin/js/signin.js
@@ -1,28 +1,34 @@
+import { sign } from '/js/common.js';
+
 const PWD_VIEW = document.querySelector('.pwd-view');
 const INPUT_EMAIL = document.querySelector('#email');
 const INPUT_PASSWORD = document.querySelector('#password');
 const FORM = document.querySelector('#login-form-box');
+const LOGIN_INFO = {
+    email: 'test@codeit.com',
+    password: 'codeit101',
+};
 
 PWD_VIEW.addEventListener('click', function () {
-    passwordSwitch(this);
+    sign.passwordSwitch(this);
 });
-INPUT_EMAIL.addEventListener('focusin', function () {
-    errorBoxDisable(this);
+INPUT_EMAIL.addEventListener('focusin', function (e) {
+    sign.errorBoxToggle(e, this);
 });
-INPUT_EMAIL.addEventListener('focusout', function () {
+INPUT_EMAIL.addEventListener('focusout', function (e) {
     if (this.value == '') {
-        errorBoxEnable(this, '이메일을 입력해 주세요.');
-    } else if (!emailValidChk(this.value)) {
-        errorBoxEnable(this, '올바른 이메일 주소가 아닙니다.');
+        sign.errorBoxToggle(e, this, '이메일을 입력해 주세요.');
+    } else if (!sign.emailValidChk(this.value)) {
+        sign.errorBoxToggle(e, this, '올바른 이메일 주소가 아닙니다.');
     }
 });
 
-INPUT_PASSWORD.addEventListener('focusin', function () {
-    errorBoxDisable(this);
+INPUT_PASSWORD.addEventListener('focusin', function (e) {
+    sign.errorBoxToggle(e, this);
 });
-INPUT_PASSWORD.addEventListener('focusout', function () {
+INPUT_PASSWORD.addEventListener('focusout', function (e) {
     if (this.value == '') {
-        errorBoxEnable(this, '비밀번호를 입력해 주세요.');
+        sign.errorBoxToggle(e, this, '비밀번호를 입력해 주세요.');
     }
 });
 
@@ -30,11 +36,12 @@ FORM.addEventListener('submit', function (e) {
     const EMAIL = this['email'];
     const PASSWORD = this['password'];
 
-    if (EMAIL.value === 'test@codeit.com' && PASSWORD.value === 'codeit101') {
+    // 로그인 정보 대조 후 submit
+    if (EMAIL.value === LOGIN_INFO.email && PASSWORD.value === LOGIN_INFO.password) {
         this.submit();
     } else {
         e.preventDefault();
-        errorBoxEnable(EMAIL, '이메일을 확인해 주세요.');
-        errorBoxEnable(PASSWORD, '비밀번호를 확인해 주세요.');
+        sign.errorBoxToggle(e, EMAIL, '이메일을 확인해 주세요.');
+        sign.errorBoxToggle(e, PASSWORD, '비밀번호를 확인해 주세요.');
     }
 });

--- a/signup/index.html
+++ b/signup/index.html
@@ -61,7 +61,6 @@
                 </div>
             </article>
         </main>
-        <script src="/js/common.js"></script>
-        <script type="text/javascript" src="/signup/js/signup.js"></script>
+        <script type="module" src="/signup/js/signup.js"></script>
     </body>
 </html>

--- a/signup/index.html
+++ b/signup/index.html
@@ -18,12 +18,12 @@
                 <form action="" method="post">
                     <div class="input-box">
                         <label for="email">이메일</label>
-                        <input type="text" id="email" class="form-input" />
+                        <input type="text" name="email" id="email" class="form-input" />
                     </div>
                     <div class="error-text" data-target="email"></div>
                     <div class="input-box">
                         <label for="password">비밀번호</label>
-                        <input type="password" id="password" class="form-input" />
+                        <input type="password" name="password" id="password" class="form-input" />
                         <div class="icon-box pwd-view" data-check="password">
                             <img src="/images/eye-off.png" alt="off" data-onoff="off" />
                         </div>
@@ -31,7 +31,12 @@
                     <div class="error-text" data-target="password"></div>
                     <div class="input-box">
                         <label for="password-confirm">비밀번호 확인</label>
-                        <input type="password" id="password-confirm" class="form-input pwd-confirm" />
+                        <input
+                            type="password"
+                            name="password-confirm"
+                            id="password-confirm"
+                            class="form-input pwd-confirm"
+                        />
                         <div class="icon-box pwd-view" data-check="password-confirm">
                             <img src="/images/eye-off.png" alt="off" data-onoff="off" />
                         </div>

--- a/signup/index.html
+++ b/signup/index.html
@@ -15,7 +15,7 @@
                     </div>
                     <div class="signin-box">이미 회원이신가요? <a href="/signin">로그인 하기</a></div>
                 </div>
-                <form action="" method="post">
+                <form id="signup-form-box" action="/folder" method="post">
                     <div class="input-box">
                         <label for="email">이메일</label>
                         <input type="text" name="email" id="email" class="form-input" />

--- a/signup/js/signup.js
+++ b/signup/js/signup.js
@@ -1,28 +1,60 @@
-import { sign } from '/js/common.js';
+import { moduleSign } from '/js/common.js';
 
-const PWD_VIEWS = document.querySelectorAll('.pwd-view');
-const PWD_CHECK = document.querySelector('.pwd-confirm');
+const INPUT_EMAIL = document.querySelector('#email');
+const INPUT_PASSWORD = document.querySelector('#password');
+const FORM = document.querySelector('#signup-form-box');
+const FORM_INPUT = document.querySelectorAll('#signup-form-box input');
+const PASSWORD_VIEWS = document.querySelectorAll('.pwd-view');
+const PASSWORD_CHECK = document.querySelector('.pwd-confirm');
 
-PWD_VIEWS.forEach((target) => {
+PASSWORD_VIEWS.forEach((target) => {
     target.addEventListener('click', () => {
-        sign.passwordSwitch(target);
+        moduleSign.passwordSwitch(target);
     });
 });
-/*
-PWD_CHECK.addEventListener('keyup', function () {
-    let pwd = document.querySelector('#password');
-    let text = document.querySelector('.error-text');
 
-    if (pwd.value != this.value) {
-        if (!this.classList.contains('error-box')) {
-            this.classList.add('error-box');
-            text.innerHTML = '비밀번호가 다릅니다.';
-            text.style.display = 'block';
-        }
-    } else {
-        this.classList.remove('error-box');
-        text.innerHTML = '';
-        text.style.display = 'none';
+PASSWORD_CHECK.addEventListener('keyup', function () {
+    moduleSign.passwordConfirm(this);
+});
+PASSWORD_CHECK.addEventListener('focusout', function () {
+    moduleSign.passwordConfirm(this);
+});
+
+INPUT_EMAIL.addEventListener('focusin', function () {
+    moduleSign.errorBoxToggle(this);
+});
+INPUT_EMAIL.addEventListener('focusout', function () {
+    if (this.value == '') {
+        moduleSign.errorBoxToggle(this, '이메일을 입력해 주세요.');
+    } else if (moduleSign.emailValidChk(this.value)) {
+        moduleSign.errorBoxToggle(this, '올바른 이메일 주소가 아닙니다.');
+    } else if (this.value == moduleSign.LOGIN_INFO.email) {
+        moduleSign.errorBoxToggle(this, '이미 사용 중인 이메일입니다.');
     }
 });
-*/
+
+INPUT_PASSWORD.addEventListener('focusin', function () {
+    moduleSign.errorBoxToggle(this);
+});
+INPUT_PASSWORD.addEventListener('focusout', function () {
+    if (this.value == '') {
+        moduleSign.errorBoxToggle(this, '비밀번호를 입력해 주세요.');
+    } else if (moduleSign.passwordRoleCheck(this.value)) {
+        moduleSign.errorBoxToggle(this, '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.');
+    }
+    // 비밀번호를 둘 다 같게 하고 원본 비밀번호를 수정하는것 방지
+    moduleSign.passwordConfirm(PASSWORD_CHECK);
+});
+
+FORM.addEventListener('submit', function (e) {
+    // 하나라도 에러가 발생하면 submit 막기
+    FORM_INPUT.forEach((el) => {
+        // focusout를 하면서 값을 다 비우고 전송하는 것 방지
+        el.focus();
+        el.blur();
+
+        if (el.classList.contains('error-box')) {
+            e.preventDefault();
+        }
+    });
+});

--- a/signup/js/signup.js
+++ b/signup/js/signup.js
@@ -1,9 +1,11 @@
+import { sign } from '/js/common.js';
+
 const PWD_VIEWS = document.querySelectorAll('.pwd-view');
 const PWD_CHECK = document.querySelector('.pwd-confirm');
 
 PWD_VIEWS.forEach((target) => {
     target.addEventListener('click', () => {
-        passwordSwitch(target);
+        sign.passwordSwitch(target);
     });
 });
 /*

--- a/signup/js/signup.js
+++ b/signup/js/signup.js
@@ -3,7 +3,7 @@ const PWD_CHECK = document.querySelector('.pwd-confirm');
 
 PWD_VIEWS.forEach((target) => {
     target.addEventListener('click', () => {
-        pwdSwitch(target);
+        passwordSwitch(target);
     });
 });
 /*


### PR DESCRIPTION
## 요구사항

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?

- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?

- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?

- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?

- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?

- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 코드리뷰 적용
- 모듈화
- 5주차 작업 완료

## 스크린샷

피그마 : https://www.figma.com/file/A7PPL7WOzACZepg9bMQRMd/Weekly-Mission%5B4%EA%B8%B0%5D?type=design&node-id=2-7942&mode=design&t=mlLq0w3H9iYx8qSj-0

클라우드 배포url : https://merry-palmier-b32b47.netlify.app/signup/

## 멘토에게

- 하나의 요소에 여러 이벤트를 적용해야할 때(콜백함수 내용 동일 이벤트만 다름) foreach로 한줄로 해결하는게 낫나요 여러줄로 선언하는게 낫나요?
