### PR TITLE
[최원석] Week5

### DIFF
--- a/SignIn.html
+++ b/SignIn.html
@@ -34,7 +34,7 @@
             /></a>
           </div>
         </div>
-        <button type="button" class="loginBtn">로그인</button>
+        <button type="button" class="login-btn">로그인</button>
         <footer>
           <div>소셜 로그인</div>
           <div class="link-box">

--- a/SignIn.html
+++ b/SignIn.html
@@ -48,6 +48,6 @@
         </footer>
       </div>
     </form>
-    <script src="script/sign.js"></script>
+    <script type="module" src="script/sign.js"></script>
   </body>
 </html>

--- a/SignUp.html
+++ b/SignUp.html
@@ -29,6 +29,9 @@
             <a href="" class="eye-off"
               ><img src="/icons/eye-off.svg" alt=""
             /></a>
+            <a href="" class="eye-on invisible"
+              ><img src="/icons/eye-on.svg" alt=""
+            /></a>
           </div>
           <label for="password-check" class="password-check-label"
             >비밀번호 확인</label
@@ -37,6 +40,9 @@
             <input type="password" id="password-check" />
             <a href="" class="eye-off-2"
               ><img src="/icons/eye-off.svg" alt=""
+            /></a>
+            <a href="" class="eye-off-2 invisible"
+              ><img src="/icons/eye-on.svg" alt=""
             /></a>
           </div>
         </div>
@@ -54,5 +60,6 @@
         </footer>
       </div>
     </form>
+    <script src="script/signUp.js"></script>
   </body>
 </html>

--- a/SignUp.html
+++ b/SignUp.html
@@ -40,7 +40,7 @@
             /></a>
           </div>
         </div>
-        <button type="button">로그인</button>
+        <button type="button" class="login-btn">로그인</button>
         <footer>
           <div>다른 방식으로 가입하기</div>
           <div class="link-box">

--- a/SignUp.html
+++ b/SignUp.html
@@ -26,7 +26,7 @@
           <label for="password">비밀번호</label>
           <div class="password-box">
             <input type="password" class="password" />
-            <a href="" class="eye-off"
+            <a href="" class="eye-off visible"
               ><img src="/icons/eye-off.svg" alt=""
             /></a>
             <a href="" class="eye-on invisible"
@@ -41,12 +41,12 @@
             <a href="" class="eye-off-2"
               ><img src="/icons/eye-off.svg" alt=""
             /></a>
-            <a href="" class="eye-off-2 invisible"
+            <a href="" class="eye-on-2 invisible"
               ><img src="/icons/eye-on.svg" alt=""
             /></a>
           </div>
         </div>
-        <button type="button" class="login-btn">로그인</button>
+        <button type="button" class="join-btn">회원가입</button>
         <footer>
           <div>다른 방식으로 가입하기</div>
           <div class="link-box">

--- a/SignUp.html
+++ b/SignUp.html
@@ -60,6 +60,6 @@
         </footer>
       </div>
     </form>
-    <script src="script/signUp.js"></script>
+    <script type="module" src="script/signUp.js"></script>
   </body>
 </html>

--- a/css/Sign.css
+++ b/css/Sign.css
@@ -8,6 +8,10 @@ body {
   display: none;
 }
 
+.visible {
+  display: inline;
+}
+
 @media (min-width: 375px) and (max-width: 767px) {
   form {
     display: flex;
@@ -89,6 +93,14 @@ body {
   }
 
   .password-error {
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    color: var(--Linkbrary-red);
+  }
+
+  .password-check-error {
     font-size: 1.4rem;
     font-style: normal;
     font-weight: 400;
@@ -301,6 +313,14 @@ body {
     color: var(--Linkbrary-red);
   }
 
+  .password-check-error {
+    font-size: 1.4rem;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    color: var(--Linkbrary-red);
+  }
+
   .password-box {
     position: relative;
   }
@@ -310,7 +330,9 @@ body {
   }
 
   .eye-off,
-  .eye-on {
+  .eye-on,
+  .eye-off-2,
+  .eye-on-2 {
     width: 1.5rem;
     height: 1.5rem;
     position: absolute;
@@ -325,13 +347,13 @@ body {
     right: 1.5rem;
   }
 
-  .eye-off-2 {
+  /* .eye-off-2 {
     width: 16px;
     height: 16px;
     position: absolute;
     top: 3.3rem;
     right: 1.5rem;
-  }
+  } */
 
   #password-check {
     margin-top: 1.2rem;

--- a/css/Sign.css
+++ b/css/Sign.css
@@ -25,7 +25,6 @@ body {
   .logo-container {
     text-align: center;
     color: var(--black, #000);
-    /* Linkbrary/body1-regular */
     font-size: 1.6rem;
     font-style: normal;
     font-weight: 400;
@@ -34,7 +33,6 @@ body {
 
   .logo-container a {
     color: var(--Linkbrary-primary-color, #6d6afe);
-    /* Linkbrary/body 1-semibold */
     font-size: 1.6rem;
     font-style: normal;
     font-weight: 600;
@@ -64,7 +62,6 @@ body {
 
   label {
     color: var(--black, #000);
-    /* Linkbrary/body2-regular */
     font-family: Pretendard;
     font-size: 14px;
     font-style: normal;
@@ -83,7 +80,6 @@ body {
   }
 
   .email-error {
-    /* background-color: blue; */
     margin-bottom: 1rem;
     font-size: 1.4rem;
     font-style: normal;
@@ -93,8 +89,6 @@ body {
   }
 
   .password-error {
-    /* background-color: blue; */
-    /* margin-bottom: 0.2rem; */
     font-size: 1.4rem;
     font-style: normal;
     font-weight: 400;
@@ -160,7 +154,6 @@ body {
 
   footer {
     color: var(--Linkbrary-gray100, #373740);
-    /* Linkbrary/body2-regular */
     font-family: Pretendard;
     font-size: 14px;
     font-style: normal;
@@ -229,7 +222,6 @@ body {
   .logo-container {
     text-align: center;
     color: var(--black, #000);
-    /* Linkbrary/body1-regular */
     font-size: 1.6rem;
     font-style: normal;
     font-weight: 400;
@@ -238,7 +230,6 @@ body {
 
   .logo-container a {
     color: var(--Linkbrary-primary-color, #6d6afe);
-    /* Linkbrary/body 1-semibold */
     font-size: 1.6rem;
     font-style: normal;
     font-weight: 600;
@@ -276,7 +267,6 @@ body {
 
   label {
     color: var(--black, #000);
-    /* Linkbrary/body2-regular */
     font-family: Pretendard;
     font-size: 14px;
     font-style: normal;
@@ -295,7 +285,6 @@ body {
   }
 
   .email-error {
-    /* background-color: blue; */
     margin-bottom: 1rem;
     font-size: 1.4rem;
     font-style: normal;
@@ -305,8 +294,6 @@ body {
   }
 
   .password-error {
-    /* background-color: blue; */
-    /* margin-bottom: 0.2rem; */
     font-size: 1.4rem;
     font-style: normal;
     font-weight: 400;
@@ -374,7 +361,6 @@ body {
 
   footer {
     color: var(--Linkbrary-gray100, #373740);
-    /* Linkbrary/body2-regular */
     font-family: Pretendard;
     font-size: 14px;
     font-style: normal;

--- a/css/style.css
+++ b/css/style.css
@@ -48,7 +48,6 @@
     display: flex;
     width: 100%;
     justify-content: space-between;
-    /* gap: 600px; */
     align-items: center;
   }
 
@@ -118,7 +117,6 @@
   }
 
   article {
-    /* padding-top: 3rem; */
     padding-bottom: 4rem;
   }
 
@@ -223,7 +221,6 @@
     display: flex;
     width: 100%;
     justify-content: space-between;
-    /* gap: 600px; */
     align-items: center;
   }
 

--- a/script/errorType.js
+++ b/script/errorType.js
@@ -1,0 +1,18 @@
+export const ERROR_MESSAGE = {
+  email: {
+    empty: "이메일을 입력해주세요.",
+    invalid: "올바른 이메일 주소가 아닙니다.",
+    check: "이메일을 확인해 주세요.",
+    inUse: "이미 사용 중인 이메일입니다.",
+  },
+  password: {
+    empty: "비밀번호을 입력해 주세요",
+    invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
+    check: "비밀번호을 확인해 주세요",
+  },
+  passwordcheck: {
+    check: "비밀번호을 확인해 주세요",
+    recheck: "비밀번호가 일치하지 않아요.",
+  },
+};
+

--- a/script/sign.js
+++ b/script/sign.js
@@ -1,3 +1,5 @@
+import { ERROR_MESSAGE } from "./errorType.js";
+
 //변수 선언
 const loginContainer = document.querySelector(".login-container");
 const inputEmail = document.querySelector(".email");
@@ -5,21 +7,6 @@ const inputPassword = document.querySelector(".password");
 const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
 const loginBtn = document.querySelector(".login-btn");
-
-const ERROR_MESSAGE = {
-  email: {
-    empty: "이메일을 입력해주세요.",
-    invalid: "올바른 이메일 주소가 아닙니다.",
-    check: "이메일을 확인해 주세요.",
-    inUse: "이미 사용 중인 이메일입니다.",
-  },
-  password: {
-    empty: "비밀번호을 입력해 주세요",
-    invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
-    check: "비밀번호을 확인해 주세요",
-    recheck: "비밀번호가 일치하지 않아요.",
-  },
-};
 
 function makeError(type, errorType) {
   const errorTag = document.createElement("p");
@@ -32,6 +19,12 @@ function makeError(type, errorType) {
     errorTag.classList.add("password-error");
     inputPassword.after(errorTag);
     inputPassword.classList.add("input-error");
+    eyeOff.classList.add("eye-error");
+    loginContainer.classList.add("error");
+  } else if (type === "passwordcheck") {
+    errorTag.classList.add("password-check-error");
+    inputPasswordCheck.after(errorTag);
+    inputPasswordCheck.classList.add("input-error");
     eyeOff.classList.add("eye-error");
     loginContainer.classList.add("error");
   }
@@ -53,9 +46,16 @@ function addEmailError() {
 
 //비밀번호에러를 추가하는 함수입니다.
 function addPasswordError() {
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+
   if (inputPassword.value === "") {
     removeIfPasswordError();
     makeError("password", ERROR_MESSAGE.password.empty);
+  }
+
+  if (inputPassword.value !== "" && !passwordRegex.test(inputPassword.value)) {
+    removeIfPasswordError();
+    makeError("password", ERROR_MESSAGE.password.invalid);
   }
 }
 

--- a/script/sign.js
+++ b/script/sign.js
@@ -6,43 +6,59 @@ const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
 const loginBtn = document.querySelector(".login-btn");
 
-//이메일이 공란일때 추가할 에러 p태그를 생성하는 함수 입니다.
-function makeEmptyEmailError() {
-  const errorEmptyEmail = document.createElement("p");
-  errorEmptyEmail.textContent = "이메일을 입력해 주세요";
-  errorEmptyEmail.classList.add("email-error");
-  inputEmail.after(errorEmptyEmail);
-  inputEmail.classList.add("input-error");
+const ERROR_MESSAGE = {
+  email: {
+    empty: "이메일을 입력해주세요.",
+    invalid: "올바른 이메일 주소가 아닙니다.",
+    check: "이메일을 확인해 주세요.",
+    inUse: "이미 사용 중인 이메일입니다.",
+  },
+  password: {
+    empty: "비밀번호을 입력해 주세요",
+    invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
+    check: "비밀번호을 확인해 주세요",
+    recheck: "비밀번호가 일치하지 않아요.",
+  },
+};
+
+function makeError(type, errorType) {
+  const errorTag = document.createElement("p");
+  errorTag.textContent = errorType;
+  if (type === "email") {
+    errorTag.classList.add("email-error");
+    inputEmail.after(errorTag);
+    inputEmail.classList.add("input-error");
+  } else if (type === "password") {
+    errorTag.classList.add("password-error");
+    inputPassword.after(errorTag);
+    inputPassword.classList.add("input-error");
+    eyeOff.classList.add("eye-error");
+    loginContainer.classList.add("error");
+  }
 }
-//이메일의 형식이 틀릴때 추가할 에러 p태그를 생성하는 함수 입니다.
-function makeWrongEmailError() {
-  const errorEmptyEmail = document.createElement("p");
-  errorEmptyEmail.textContent = "올바른 이메일 주소가 아닙니다.";
-  errorEmptyEmail.classList.add("email-error");
-  inputEmail.after(errorEmptyEmail);
-  inputEmail.classList.add("input-error");
-}
-//이메일을 확인할때의 에러 p태그를 생성하는 함수 입니다.
-function makeCheckEmailError() {
-  const errorEmptyEmail = document.createElement("p");
-  errorEmptyEmail.textContent = "이메일을 확인해 주세요";
-  errorEmptyEmail.classList.add("email-error");
-  inputEmail.after(errorEmptyEmail);
-  inputEmail.classList.add("input-error");
-}
+
 //이메일에러를 추가하는 함수입니다.
 function addEmailError() {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 간단한 이메일 유효성 검사 정규식
 
   if (inputEmail.value === "") {
     removeIfEmailError();
-    makeEmptyEmailError();
+    makeError("email", ERROR_MESSAGE.email.empty);
   }
   if (inputEmail.value !== "" && !emailRegex.test(inputEmail.value)) {
     removeIfEmailError();
-    makeWrongEmailError();
+    makeError("email", ERROR_MESSAGE.email.check);
   }
 }
+
+//비밀번호에러를 추가하는 함수입니다.
+function addPasswordError() {
+  if (inputPassword.value === "") {
+    removeIfPasswordError();
+    makeError("password", ERROR_MESSAGE.password.empty);
+  }
+}
+
 //이메일에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
 function removeIfEmailError() {
   const errorEmptyEmail = document.querySelector(".email-error");
@@ -52,35 +68,7 @@ function removeIfEmailError() {
     inputEmail.classList.remove("input-error");
   }
 }
-//비밀번호가 공란일때 에러 p태그를 생성하는 함수입니다.
-//오류함수를 합치고 싶었으나 에러 태그를 생성하면 눈 이미지의 위치변화도 있기 때문에
-//이메일과 비밀번호 에러 생성함수를 따로 만들었습니다.
-function makeEmptyPasswordError() {
-  const errorEmptyPassword = document.createElement("p");
-  errorEmptyPassword.textContent = "비밀번호를 입력해 주세요";
-  errorEmptyPassword.classList.add("password-error");
-  inputPassword.after(errorEmptyPassword);
-  inputPassword.classList.add("input-error");
-  eyeOff.classList.add("eye-error");
-  loginContainer.classList.add("error");
-}
-//비밀번호가 유효하지 않을때 에러 p태그를 생성하는 함수입니다.
-function makeCheckPasswordError() {
-  const errorEmptyPassword = document.createElement("p");
-  errorEmptyPassword.textContent = "비밀번호를 확인해 주세요";
-  errorEmptyPassword.classList.add("password-error");
-  inputPassword.after(errorEmptyPassword);
-  inputPassword.classList.add("input-error");
-  eyeOff.classList.add("eye-error");
-  loginContainer.classList.add("error");
-}
-//비밀번호에러를 추가하는 함수입니다.
-function addPasswordError() {
-  if (inputPassword.value === "") {
-    removeIfPasswordError();
-    makeEmptyPasswordError();
-  }
-}
+
 //비밀번호에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
 function removeIfPasswordError() {
   const errorEmptyPassword = document.querySelector(".password-error");
@@ -102,8 +90,8 @@ function Login() {
   } else {
     removeIfEmailError();
     removeIfPasswordError();
-    makeCheckEmailError();
-    makeCheckPasswordError();
+    makeError("email", ERROR_MESSAGE.email.check);
+    makeError("password", ERROR_MESSAGE.password.check);
   }
 }
 //keypress가 일어났을때 Enter키를 눌렀는지 확인하고 Login()을 실행하는 함수입니다.

--- a/script/sign.js
+++ b/script/sign.js
@@ -4,7 +4,7 @@ const inputEmail = document.querySelector(".email");
 const inputPassword = document.querySelector(".password");
 const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
-const loginBtn = document.querySelector(".loginBtn");
+const loginBtn = document.querySelector(".login-btn");
 
 //이메일이 공란일때 추가할 에러 p태그를 생성하는 함수 입니다.
 function makeEmptyEmailError() {

--- a/script/sign.js
+++ b/script/sign.js
@@ -8,6 +8,7 @@ const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
 const loginBtn = document.querySelector(".login-btn");
 
+//에러태그를 생성하는 함수 입니다.
 function makeError(type, errorType) {
   const errorTag = document.createElement("p");
   errorTag.textContent = errorType;

--- a/script/signUp.js
+++ b/script/signUp.js
@@ -2,9 +2,13 @@
 const loginContainer = document.querySelector(".login-container");
 const inputEmail = document.querySelector(".email");
 const inputPassword = document.querySelector(".password");
+const inputPasswordCheck = document.querySelector("#password-check");
 const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
+const eyeOff_2 = document.querySelector(".eye-off-2");
+const eyeOn_2 = document.querySelector(".eye-on-2");
 const loginBtn = document.querySelector(".login-btn");
+const joinBtn = document.querySelector(".join-btn");
 
 const ERROR_MESSAGE = {
   email: {
@@ -16,6 +20,9 @@ const ERROR_MESSAGE = {
   password: {
     empty: "비밀번호을 입력해 주세요",
     invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
+    check: "비밀번호을 확인해 주세요",
+  },
+  passwordcheck: {
     check: "비밀번호을 확인해 주세요",
     recheck: "비밀번호가 일치하지 않아요.",
   },
@@ -32,6 +39,12 @@ function makeError(type, errorType) {
     errorTag.classList.add("password-error");
     inputPassword.after(errorTag);
     inputPassword.classList.add("input-error");
+    eyeOff.classList.add("eye-error");
+    loginContainer.classList.add("error");
+  } else if (type === "passwordcheck") {
+    errorTag.classList.add("password-check-error");
+    inputPasswordCheck.after(errorTag);
+    inputPasswordCheck.classList.add("input-error");
     eyeOff.classList.add("eye-error");
     loginContainer.classList.add("error");
   }
@@ -63,6 +76,14 @@ function addPasswordError() {
   }
 }
 
+//비밀번호확인 에러를 추가하는 함수입니다.
+function addPasswordCheckError() {
+  if (inputPasswordCheck.value !== inputPassword.value) {
+    removeIfPasswordCheckError();
+    makeError("passwordcheck", ERROR_MESSAGE.passwordcheck.recheck);
+  }
+}
+
 //이메일에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
 function removeIfEmailError() {
   const errorEmptyEmail = document.querySelector(".email-error");
@@ -84,24 +105,41 @@ function removeIfPasswordError() {
     loginContainer.classList.remove("error");
   }
 }
+
+//비밀번호에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
+function removeIfPasswordCheckError() {
+  const errorEmptyPasswordCheck = document.querySelector(
+    ".password-check-error"
+  );
+
+  if (errorEmptyPasswordCheck) {
+    errorEmptyPasswordCheck.remove();
+    inputPasswordCheck.classList.remove("input-error");
+    eyeOff.classList.remove("eye-error");
+    loginContainer.classList.remove("error");
+  }
+}
+
 //로그인 버튼의 이벤트를 구현한 함수입니다.
-function Login() {
+function join() {
   if (
-    inputEmail.value === "test@codeit.com" &&
-    inputPassword.value === "codeit101"
+    inputEmail.value !== "test@codeit.com" &&
+    inputPassword.value === inputPasswordCheck.value
   ) {
     window.location.assign("./folder");
   } else {
     removeIfEmailError();
     removeIfPasswordError();
-    makeError("email", ERROR_MESSAGE.email.check);
-    makeError("password", ERROR_MESSAGE.password.check);
+    removeIfPasswordCheckError();
+    addEmailError();
+    addPasswordError();
+    addPasswordCheckError();
   }
 }
 //keypress가 일어났을때 Enter키를 눌렀는지 확인하고 Login()을 실행하는 함수입니다.
-function enterLogin(e) {
+function enterjoin(e) {
   if (e.key === "Enter") {
-    Login();
+    join();
     e.preventDefault();
   }
 }
@@ -109,16 +147,29 @@ function enterLogin(e) {
 function eyeClick(e) {
   console.log(e.target.parentElement);
   if (e.target.parentElement === eyeOff) {
-    eyeOff.classList.add("invisible");
+    eyeOff.classList.add("visible");
     eyeOn.classList.remove("invisible");
     inputPassword.type = "text";
   }
   if (e.target.parentElement === eyeOn) {
     eyeOn.classList.add("invisible");
-    eyeOff.classList.remove("invisible");
+    eyeOff.classList.remove("visible");
     inputPassword.type = "password";
   }
-
+  e.preventDefault();
+}
+function eyeClick_2(e) {
+  console.log(e.target.parentElement);
+  if (e.target.parentElement === eyeOff_2) {
+    eyeOff_2.classList.add("visible");
+    eyeOn_2.classList.remove("invisible");
+    inputPasswordCheck.type = "text";
+  }
+  if (e.target.parentElement === eyeOn_2) {
+    eyeOn_2.classList.add("invisible");
+    eyeOff_2.classList.remove("visible");
+    inputPasswordCheck.type = "password";
+  }
   e.preventDefault();
 }
 
@@ -127,7 +178,11 @@ inputEmail.addEventListener("focusout", addEmailError);
 inputEmail.addEventListener("focusin", removeIfEmailError);
 inputPassword.addEventListener("focusout", addPasswordError);
 inputPassword.addEventListener("focusin", removeIfPasswordError);
-loginBtn.addEventListener("click", Login);
-document.body.addEventListener("keypress", enterLogin);
+inputPasswordCheck.addEventListener("focusout", addPasswordCheckError);
+inputPasswordCheck.addEventListener("focusin", removeIfPasswordCheckError);
+joinBtn.addEventListener("click", join);
+document.body.addEventListener("keypress", enterjoin);
 eyeOff.addEventListener("click", eyeClick);
 eyeOn.addEventListener("click", eyeClick);
+eyeOff_2.addEventListener("click", eyeClick_2);
+eyeOn_2.addEventListener("click", eyeClick_2);

--- a/script/signUp.js
+++ b/script/signUp.js
@@ -12,6 +12,7 @@ const eyeOff_2 = document.querySelector(".eye-off-2");
 const eyeOn_2 = document.querySelector(".eye-on-2");
 const joinBtn = document.querySelector(".join-btn");
 
+//에러태그를 생성하는 함수 입니다.
 function makeError(type, errorType) {
   const errorTag = document.createElement("p");
   errorTag.textContent = errorType;
@@ -111,7 +112,7 @@ function removeIfPasswordCheckError() {
   }
 }
 
-//로그인 버튼의 이벤트를 구현한 함수입니다.
+//회원가입 버튼의 이벤트를 구현한 함수입니다.
 function join() {
   if (
     emailValid(inputEmail.value) &&
@@ -120,11 +121,6 @@ function join() {
   ) {
     window.location.assign("./folder");
   } else {
-    console.log(
-      emailValid(inputEmail.value) &&
-        passwordValid(inputPassword.value) &&
-        isPasswordSame(inputPassword.value, inputPasswordCheck.value)
-    );
     removeIfEmailError();
     removeIfPasswordError();
     removeIfPasswordCheckError();
@@ -133,7 +129,7 @@ function join() {
     addPasswordCheckError();
   }
 }
-//keypress가 일어났을때 Enter키를 눌렀는지 확인하고 Login()을 실행하는 함수입니다.
+//keypress가 일어났을때 Enter키를 눌렀는지 확인하고 join()을 실행하는 함수입니다.
 function enterjoin(e) {
   if (e.key === "Enter") {
     join();
@@ -154,7 +150,7 @@ function eyeClick(e) {
   }
   e.preventDefault();
 }
-
+//비밀번호 확인에 있는 이미지를 클릭했을때 눈의 이미지를 토글하는 함수입니다. 토글시 비밀번호의 노출여부도 바뀝니다.
 function eyeClick_2(e) {
   if (e.target.parentElement === eyeOff_2) {
     eyeOff_2.classList.add("visible");

--- a/script/signUp.js
+++ b/script/signUp.js
@@ -1,0 +1,133 @@
+//변수 선언
+const loginContainer = document.querySelector(".login-container");
+const inputEmail = document.querySelector(".email");
+const inputPassword = document.querySelector(".password");
+const eyeOff = document.querySelector(".eye-off");
+const eyeOn = document.querySelector(".eye-on");
+const loginBtn = document.querySelector(".login-btn");
+
+const ERROR_MESSAGE = {
+  email: {
+    empty: "이메일을 입력해주세요.",
+    invalid: "올바른 이메일 주소가 아닙니다.",
+    check: "이메일을 확인해 주세요.",
+    inUse: "이미 사용 중인 이메일입니다.",
+  },
+  password: {
+    empty: "비밀번호을 입력해 주세요",
+    invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
+    check: "비밀번호을 확인해 주세요",
+    recheck: "비밀번호가 일치하지 않아요.",
+  },
+};
+
+function makeError(type, errorType) {
+  const errorTag = document.createElement("p");
+  errorTag.textContent = errorType;
+  if (type === "email") {
+    errorTag.classList.add("email-error");
+    inputEmail.after(errorTag);
+    inputEmail.classList.add("input-error");
+  } else if (type === "password") {
+    errorTag.classList.add("password-error");
+    inputPassword.after(errorTag);
+    inputPassword.classList.add("input-error");
+    eyeOff.classList.add("eye-error");
+    loginContainer.classList.add("error");
+  }
+}
+
+//이메일에러를 추가하는 함수입니다.
+function addEmailError() {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 간단한 이메일 유효성 검사 정규식
+
+  if (inputEmail.value === "") {
+    removeIfEmailError();
+    makeError("email", ERROR_MESSAGE.email.empty);
+  }
+  if (inputEmail.value !== "" && !emailRegex.test(inputEmail.value)) {
+    removeIfEmailError();
+    makeError("email", ERROR_MESSAGE.email.check);
+  }
+  if (inputEmail.value === "test@codeit.com") {
+    removeIfEmailError();
+    makeError("email", ERROR_MESSAGE.email.inUse);
+  }
+}
+
+//비밀번호에러를 추가하는 함수입니다.
+function addPasswordError() {
+  if (inputPassword.value === "") {
+    removeIfPasswordError();
+    makeError("password", ERROR_MESSAGE.password.empty);
+  }
+}
+
+//이메일에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
+function removeIfEmailError() {
+  const errorEmptyEmail = document.querySelector(".email-error");
+
+  if (errorEmptyEmail) {
+    errorEmptyEmail.remove();
+    inputEmail.classList.remove("input-error");
+  }
+}
+
+//비밀번호에서 오류태그인 p태그가 연속적으로 쌓이는 것을 방지하기 위한 에러태그가 있다면 제거하는 함수입니다.
+function removeIfPasswordError() {
+  const errorEmptyPassword = document.querySelector(".password-error");
+
+  if (errorEmptyPassword) {
+    errorEmptyPassword.remove();
+    inputPassword.classList.remove("input-error");
+    eyeOff.classList.remove("eye-error");
+    loginContainer.classList.remove("error");
+  }
+}
+//로그인 버튼의 이벤트를 구현한 함수입니다.
+function Login() {
+  if (
+    inputEmail.value === "test@codeit.com" &&
+    inputPassword.value === "codeit101"
+  ) {
+    window.location.assign("./folder");
+  } else {
+    removeIfEmailError();
+    removeIfPasswordError();
+    makeError("email", ERROR_MESSAGE.email.check);
+    makeError("password", ERROR_MESSAGE.password.check);
+  }
+}
+//keypress가 일어났을때 Enter키를 눌렀는지 확인하고 Login()을 실행하는 함수입니다.
+function enterLogin(e) {
+  if (e.key === "Enter") {
+    Login();
+    e.preventDefault();
+  }
+}
+//눈이미지를 클릭했을때 눈의 이미지를 토글하는 함수입니다. 토글시 비밀번호의 노출여부도 바뀝니다.
+function eyeClick(e) {
+  console.log(e.target.parentElement);
+  if (e.target.parentElement === eyeOff) {
+    eyeOff.classList.add("invisible");
+    eyeOn.classList.remove("invisible");
+    inputPassword.type = "text";
+  }
+  if (e.target.parentElement === eyeOn) {
+    eyeOn.classList.add("invisible");
+    eyeOff.classList.remove("invisible");
+    inputPassword.type = "password";
+  }
+
+  e.preventDefault();
+}
+
+//이벤트 핸들러 적용
+inputEmail.addEventListener("focusout", addEmailError);
+inputEmail.addEventListener("focusin", removeIfEmailError);
+inputPassword.addEventListener("focusout", addPasswordError);
+inputPassword.addEventListener("focusin", removeIfPasswordError);
+loginBtn.addEventListener("click", Login);
+document.body.addEventListener("keypress", enterLogin);
+eyeOff.addEventListener("click", eyeClick);
+eyeOn.addEventListener("click", eyeClick);

--- a/script/signUp.js
+++ b/script/signUp.js
@@ -1,3 +1,6 @@
+import { emailValid, passwordValid, isPasswordSame } from "./valid.js";
+import { ERROR_MESSAGE } from "./errorType.js";
+
 //변수 선언
 const loginContainer = document.querySelector(".login-container");
 const inputEmail = document.querySelector(".email");
@@ -7,26 +10,7 @@ const eyeOff = document.querySelector(".eye-off");
 const eyeOn = document.querySelector(".eye-on");
 const eyeOff_2 = document.querySelector(".eye-off-2");
 const eyeOn_2 = document.querySelector(".eye-on-2");
-const loginBtn = document.querySelector(".login-btn");
 const joinBtn = document.querySelector(".join-btn");
-
-const ERROR_MESSAGE = {
-  email: {
-    empty: "이메일을 입력해주세요.",
-    invalid: "올바른 이메일 주소가 아닙니다.",
-    check: "이메일을 확인해 주세요.",
-    inUse: "이미 사용 중인 이메일입니다.",
-  },
-  password: {
-    empty: "비밀번호을 입력해 주세요",
-    invalid: "비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.",
-    check: "비밀번호을 확인해 주세요",
-  },
-  passwordcheck: {
-    check: "비밀번호을 확인해 주세요",
-    recheck: "비밀번호가 일치하지 않아요.",
-  },
-};
 
 function makeError(type, errorType) {
   const errorTag = document.createElement("p");
@@ -70,9 +54,16 @@ function addEmailError() {
 
 //비밀번호에러를 추가하는 함수입니다.
 function addPasswordError() {
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+
   if (inputPassword.value === "") {
     removeIfPasswordError();
     makeError("password", ERROR_MESSAGE.password.empty);
+  }
+
+  if (inputPassword.value !== "" && !passwordRegex.test(inputPassword.value)) {
+    removeIfPasswordError();
+    makeError("password", ERROR_MESSAGE.password.invalid);
   }
 }
 
@@ -123,11 +114,17 @@ function removeIfPasswordCheckError() {
 //로그인 버튼의 이벤트를 구현한 함수입니다.
 function join() {
   if (
-    inputEmail.value !== "test@codeit.com" &&
-    inputPassword.value === inputPasswordCheck.value
+    emailValid(inputEmail.value) &&
+    passwordValid(inputPassword.value) &&
+    isPasswordSame(inputPassword.value, inputPasswordCheck.value)
   ) {
     window.location.assign("./folder");
   } else {
+    console.log(
+      emailValid(inputEmail.value) &&
+        passwordValid(inputPassword.value) &&
+        isPasswordSame(inputPassword.value, inputPasswordCheck.value)
+    );
     removeIfEmailError();
     removeIfPasswordError();
     removeIfPasswordCheckError();
@@ -145,7 +142,6 @@ function enterjoin(e) {
 }
 //눈이미지를 클릭했을때 눈의 이미지를 토글하는 함수입니다. 토글시 비밀번호의 노출여부도 바뀝니다.
 function eyeClick(e) {
-  console.log(e.target.parentElement);
   if (e.target.parentElement === eyeOff) {
     eyeOff.classList.add("visible");
     eyeOn.classList.remove("invisible");
@@ -158,8 +154,8 @@ function eyeClick(e) {
   }
   e.preventDefault();
 }
+
 function eyeClick_2(e) {
-  console.log(e.target.parentElement);
   if (e.target.parentElement === eyeOff_2) {
     eyeOff_2.classList.add("visible");
     eyeOn_2.classList.remove("invisible");

--- a/script/valid.js
+++ b/script/valid.js
@@ -1,0 +1,24 @@
+function emailValid(email) {
+  const EXIST_EMAIL = "test@codeit.com";
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 간단한 이메일 유효성 검사 정규식
+  if (email !== EXIST_EMAIL && email !== "" && emailRegex.test(email)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function passwordValid(password) {
+  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+  if (password !== "" && passwordRegex.test(password)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function isPasswordSame(password1, password2) {
+  return password1 === password2 ? true : false;
+}
+
+export { emailValid, passwordValid, isPasswordSame };

--- a/script/valid.js
+++ b/script/valid.js
@@ -1,3 +1,4 @@
+//이메일 유효성을 검사하는 함수입니다.
 function emailValid(email) {
   const EXIST_EMAIL = "test@codeit.com";
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/; // 간단한 이메일 유효성 검사 정규식
@@ -8,6 +9,7 @@ function emailValid(email) {
   }
 }
 
+//비밀번호 유효성을 검사하는 함수입니다.
 function passwordValid(password) {
   const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
   if (password !== "" && passwordRegex.test(password)) {
@@ -17,6 +19,7 @@ function passwordValid(password) {
   }
 }
 
+//비밀번호가 같은지 검사하는 함수입니다.
 function isPasswordSame(password1, password2) {
   return password1 === password2 ? true : false;
 }


### PR DESCRIPTION
## 요구사항

## 기본
- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [ ] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?
## 심화
- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-
-

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/107683008/e9623e12-5bb8-4aee-b773-0a5050616557)
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/107683008/e8926e7d-6291-4a65-841e-70884a55e674)

## 멘토에게

- 코드를 깔끔하게 정리하는게 어려운 것 같습니다. ㅠㅜ
- 겹치는 부분 모듈로 정리하려고 했으나 너무 바꿀게 많아서 모듈로 마음처럼 깔끔하게 정리하지 못했습니다. 다음부터는 처음부터 조금씩 코드를 정리하면서 코드를 짜겠습니다. 
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
