### PR TITLE
[정사비비] Week5

### DIFF
--- a/faq/faq.html
+++ b/faq/faq.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body></body>
+</html>

--- a/folder/folder.html
+++ b/folder/folder.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/privacy/privacy.html
+++ b/privacy/privacy.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body></body>
+</html>

--- a/signin/signin.html
+++ b/signin/signin.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/signin/signin.html
+++ b/signin/signin.html
@@ -16,7 +16,7 @@
           회원이 아니신가요?<a class="move_signup" href="../signup/signup.html">회원 가입하기</a>
         </div>
       </div>
-      <form id="form">
+      <form>
         <div>
           <label for="email">이메일</label>
           <input id="email" name="email" type="email" />
@@ -45,6 +45,6 @@
         </div>
       </div>
     </main>
-    <script src="signin.js"></script>
+    <script type="module" src="signin.js"></script>
   </body>
 </html>

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -1,19 +1,19 @@
-import { isEmail } from '../src/common/sign.js';
+import {
+  form,
+  email,
+  emailError,
+  eyeIcon,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  isEmail,
+  removeEmpty,
+  eyeIconOn,
+  eyeIconOff,
+} from '../src/common/sign.js';
 
-const form = document.querySelector('form');
-
-const email = document.querySelector('#email');
 const password = document.querySelector('#password');
 
-const emailError = document.querySelector('.email-error');
 const passwordError = document.querySelector('.password-error');
-
-const eyeIcon = document.querySelector('.icon');
-const eyeIconOn = document.querySelector('.eye-icon-on');
-const eyeIconOff = document.querySelector('.eye-icon-off');
-
-const TEST_EMAIL = 'test@codeit.com';
-const TEST_PASSWORD = 'codeit101';
 
 const onSubmit = (e) => {
   e.preventDefault();
@@ -24,22 +24,6 @@ const onSubmit = (e) => {
     emailError.textContent = '이메일을 확인해 주세요.';
     passwordError.textContent = '비밀번호를 확인해 주세요.';
   }
-};
-
-const togglePasswordVisibility = () => {
-  if (password.type === 'password') {
-    password.type = 'text';
-    eyeIconOff.style.display = 'none';
-    eyeIconOn.style.display = 'inline-block';
-  } else {
-    password.type = 'password';
-    eyeIconOff.style.display = 'inline-block';
-    eyeIconOn.style.display = 'none';
-  }
-};
-
-const removeEmpty = (input) => {
-  return input.replace(/(\s*)/g, '');
 };
 
 const emailInputCheck = (e) => {
@@ -66,6 +50,18 @@ const passwordInputCheck = (e) => {
   } else {
     passwordError.textContent = '';
     e.target.classList.remove('inputError');
+  }
+};
+
+const togglePasswordVisibility = () => {
+  if (password.type === 'password') {
+    password.type = 'text';
+    eyeIconOff.style.display = 'none';
+    eyeIconOn.style.display = 'inline-block';
+  } else {
+    password.type = 'password';
+    eyeIconOff.style.display = 'inline-block';
+    eyeIconOn.style.display = 'none';
   }
 };
 

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -2,6 +2,7 @@ import {
   form,
   email,
   emailError,
+  passwordError,
   eyeIcon,
   TEST_EMAIL,
   TEST_PASSWORD,
@@ -12,8 +13,6 @@ import {
 } from '../src/common/sign.js';
 
 const password = document.querySelector('#password');
-
-const passwordError = document.querySelector('.password-error');
 
 const onSubmit = (e) => {
   e.preventDefault();
@@ -56,12 +55,12 @@ const passwordInputCheck = (e) => {
 const togglePasswordVisibility = () => {
   if (password.type === 'password') {
     password.type = 'text';
-    eyeIconOff.style.display = 'none';
-    eyeIconOn.style.display = 'inline-block';
+    eyeIconOff[0].style.display = 'none';
+    eyeIconOn[0].style.display = 'inline-block';
   } else {
     password.type = 'password';
-    eyeIconOff.style.display = 'inline-block';
-    eyeIconOn.style.display = 'none';
+    eyeIconOff[0].style.display = 'inline-block';
+    eyeIconOn[0].style.display = 'none';
   }
 };
 
@@ -77,4 +76,4 @@ email.addEventListener('focusout', emailInputCheck);
 
 password.addEventListener('focusout', passwordInputCheck);
 
-eyeIcon.addEventListener('click', eyeIconClick);
+eyeIcon[0].addEventListener('click', eyeIconClick);

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -1,4 +1,6 @@
-const form = document.querySelector('#form');
+import { isEmail } from '../src/common/sign.js';
+
+const form = document.querySelector('form');
 
 const email = document.querySelector('#email');
 const password = document.querySelector('#password');
@@ -10,50 +12,21 @@ const eyeIcon = document.querySelector('.icon');
 const eyeIconOn = document.querySelector('.eye-icon-on');
 const eyeIconOff = document.querySelector('.eye-icon-off');
 
-function onSubmit(e) {
+const TEST_EMAIL = 'test@codeit.com';
+const TEST_PASSWORD = 'codeit101';
+
+const onSubmit = (e) => {
   e.preventDefault();
 
-  if (email.value === 'test@codeit.com' && password.value === 'codeit101') {
+  if (email.value === TEST_EMAIL && password.value === TEST_PASSWORD) {
     location.href = '/folder/folder.html';
   } else {
     emailError.textContent = '이메일을 확인해 주세요.';
     passwordError.textContent = '비밀번호를 확인해 주세요.';
   }
-}
+};
 
-function isEmail(asValue) {
-  let regExp =
-    /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
-
-  return regExp.test(asValue);
-}
-
-email.addEventListener('focusout', function (e) {
-  if (e.target.value.length <= 0) {
-    emailError.textContent = '이메일을 입력해 주세요.';
-    e.target.classList.add('inputError');
-  } else {
-    if (!isEmail(email.value)) {
-      emailError.textContent = '올바른 이메일 주소가 아닙니다.';
-      e.target.classList.add('inputError');
-    } else {
-      emailError.textContent = '';
-      e.target.classList.remove('inputError');
-    }
-  }
-});
-
-password.addEventListener('focusout', function (e) {
-  if (e.target.value.length <= 0) {
-    passwordError.textContent = '비밀번호를 입력해 주세요.';
-    e.target.classList.add('inputError');
-  } else {
-    passwordError.textContent = '';
-    e.target.classList.remove('inputError');
-  }
-});
-
-function togglePasswordVisibility() {
+const togglePasswordVisibility = () => {
   if (password.type === 'password') {
     password.type = 'text';
     eyeIconOff.style.display = 'none';
@@ -63,12 +36,41 @@ function togglePasswordVisibility() {
     eyeIconOff.style.display = 'inline-block';
     eyeIconOn.style.display = 'none';
   }
-}
+};
 
-form.addEventListener('submit', onSubmit);
+const emailInputCheck = (e) => {
+  if (e.target.value.length <= 0) {
+    emailError.textContent = '이메일을 입력해 주세요.';
+    e.target.classList.add('inputError');
+  } else if (!isEmail(email.value)) {
+    emailError.textContent = '올바른 이메일 주소가 아닙니다.';
+    e.target.classList.add('inputError');
+  } else {
+    emailError.textContent = '';
+    e.target.classList.remove('inputError');
+  }
+};
 
-eyeIcon.addEventListener('click', function (e) {
+const passwordInputCheck = (e) => {
+  if (e.target.value.length <= 0) {
+    passwordError.textContent = '비밀번호를 입력해 주세요.';
+    e.target.classList.add('inputError');
+  } else {
+    passwordError.textContent = '';
+    e.target.classList.remove('inputError');
+  }
+};
+
+const eyeIconClick = (e) => {
   if (e.target.classList.contains('eye-icon')) {
     togglePasswordVisibility();
   }
-});
+};
+
+form.addEventListener('submit', onSubmit);
+
+email.addEventListener('focusout', emailInputCheck);
+
+password.addEventListener('focusout', passwordInputCheck);
+
+eyeIcon.addEventListener('click', eyeIconClick);

--- a/signin/signin.js
+++ b/signin/signin.js
@@ -38,7 +38,13 @@ const togglePasswordVisibility = () => {
   }
 };
 
+const removeEmpty = (input) => {
+  return input.replace(/(\s*)/g, '');
+};
+
 const emailInputCheck = (e) => {
+  e.target.value = removeEmpty(e.target.value);
+
   if (e.target.value.length <= 0) {
     emailError.textContent = '이메일을 입력해 주세요.';
     e.target.classList.add('inputError');
@@ -52,6 +58,8 @@ const emailInputCheck = (e) => {
 };
 
 const passwordInputCheck = (e) => {
+  e.target.value = removeEmpty(e.target.value);
+
   if (e.target.value.length <= 0) {
     passwordError.textContent = '비밀번호를 입력해 주세요.';
     e.target.classList.add('inputError');

--- a/signup/signup-style.css
+++ b/signup/signup-style.css
@@ -75,23 +75,40 @@ input {
   align-items: center;
   border-radius: 0.8rem;
   border: 1px solid var(--gray20);
-  background: var(--Linkbrary-white, #fff);
   line-height: 150%;
   font-size: 1.6rem;
+}
+
+input:focus {
+  border-color: var(--primary);
+}
+
+.error {
+  color: var(--red);
+  font-size: 1.4rem;
+  margin-top: 0.6rem;
+}
+
+.inputError {
+  border-color: var(--red);
 }
 
 .signup_button {
   display: flex;
   width: 100%;
   padding: 16px 20px;
+  margin-top: 0.6rem;
   justify-content: center;
   align-items: center;
   gap: 10px;
   border-radius: 8px;
-  background: linear-gradient(91deg, var(--primary) 0.12%, #6ae3fe 101.84%);
+  background: var(
+    --gra-purpleblue-to-skyblue,
+    linear-gradient(91deg, var(--primary) 0.12%, #6ae3fe 101.84%)
+  );
   text-decoration: none;
-  color: #f5f5f5;
-  font-size: 1.8rem;
+  color: var(--Grey-Light, #f5f5f5);
+  font-size: 18px;
   font-weight: 600;
 }
 
@@ -109,14 +126,15 @@ input {
   font-size: 1.4rem;
 }
 
-.signup_block a {
-  width: 4.2rem;
-  height: 4.2rem;
+.signup_block img {
+  width: 42px;
+  height: 42px;
   flex-shrink: 0;
 }
 
 .social_signup_img {
   display: flex;
+  align-items: flex-start;
   gap: 16px;
 }
 
@@ -124,13 +142,25 @@ input {
   position: relative;
 }
 
-.eye-button {
+.icon {
+  position: relative;
+}
+
+.icon {
+  position: relative;
+}
+
+.eye-icon {
   position: absolute;
   right: 1.5rem;
   bottom: 2.2rem;
   width: 1.6rem;
   height: 1.6rem;
-  fill: #fff;
+  cursor: pointer;
+}
+
+.eye-icon-on {
+  display: none;
 }
 
 /* Tablet 사이즈 */

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/signup/signup.html
+++ b/signup/signup.html
@@ -19,20 +19,29 @@
       <form>
         <div>
           <label for="email">이메일</label>
-          <input id="email" name="email" />
+          <input id="email" name="email" type="email" />
+          <div class="error email-error"></div>
         </div>
         <div class="password_block">
           <label class="password" for="password">비밀번호</label>
-          <input id="password" name="password" />
-          <button class="eye-button"><img src="/image/eye-on.svg" alt="password check" /></button>
+          <div class="icon">
+            <input class="password_check" name="password" type="password" />
+            <img class="eye-icon eye-icon-off" src="/image/eye-off.svg" alt="password not check" />
+            <img class="eye-icon eye-icon-on" src="/image/eye-on.svg" alt="password check" />
+          </div>
+          <div class="error password-error"></div>
         </div>
         <div class="password_block">
           <label class="password" for="password">비밀번호 확인</label>
-          <input id="password" name="password" />
-          <button class="eye-button"><img src="/image/eye-on.svg" alt="password check" /></button>
+          <div class="icon">
+            <input class="password_recheck" name="password" type="password" />
+            <img class="eye-icon eye-icon-off" src="/image/eye-off.svg" alt="password not check" />
+            <img class="eye-icon eye-icon-on" src="/image/eye-on.svg" alt="password check" />
+          </div>
+          <div class="error password-error-check"></div>
         </div>
+        <button type="submit" class="signup_button">회원가입</button>
       </form>
-      <a class="signup_button" href="">회원가입</a>
       <div class="signup_block">
         <span>다른 방식으로 가입하기</span>
         <div class="social_signup_img">
@@ -45,5 +54,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="./signup.js"></script>
   </body>
 </html>

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -15,46 +15,87 @@ const passwordReCheck = document.querySelector('.password_recheck');
 const passwordError = document.querySelector('.password-error');
 const passwordErrorCheck = document.querySelector('.password-error-check');
 
+let isValid = [false, false, false];
+
+const onSubmit = (e) => {
+  e.preventDefault();
+
+  if (isValid[0] === false) emailError.textContent = '이메일을 확인해 주세요.';
+  if (isValid[1] === false) passwordError.textContent = '비밀번호를 확인해 주세요.';
+  if (isValid[2] === false) passwordErrorCheck.textContent = '비밀번호를 확인해 주세요.';
+  else location.href = '/folder/folder.html';
+};
+
 const emailInputCheck = (e) => {
   e.target.value = removeEmpty(e.target.value);
 
   if (e.target.value.length <= 0) {
     emailError.textContent = '이메일을 입력해 주세요.';
     e.target.classList.add('inputError');
+    isValid[0] = false;
   } else if (!isEmail(email.value)) {
     emailError.textContent = '올바른 이메일 주소가 아닙니다.';
     e.target.classList.add('inputError');
+    isValid[0] = false;
   } else if (e.target.value === TEST_EMAIL) {
     emailError.textContent = '이미 사용 중인 이메일입니다.';
+    isValid[0] = false;
   } else {
     emailError.textContent = '';
     e.target.classList.remove('inputError');
+    isValid[0] = true;
   }
 };
 
 const passwordInputCheck = (e) => {
   e.target.value = removeEmpty(e.target.value);
 
-  if (e.target.value.length < 8 || !/\d/.test(e.target.value) || !/[a-zA-Z]/.test(e.target.value)) {
+  if (e.target.value.length <= 0) {
+    passwordError.textContent = '비밀번호를 입력해 주세요.';
+    e.target.classList.add('inputError');
+    isValid[1] = false;
+  } else if (
+    e.target.value.length < 8 ||
+    !/\d/.test(e.target.value) ||
+    !/[a-zA-Z]/.test(e.target.value)
+  ) {
     passwordError.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
     e.target.classList.add('inputError');
+    isValid[1] = false;
   } else {
     passwordError.textContent = '';
     e.target.classList.remove('inputError');
+    isValid[1] = true;
   }
 };
 
 const passwordInputRecheck = (e) => {
   e.target.value = removeEmpty(e.target.value);
 
-  if (passwordCheck.value !== e.target.value) {
+  if (e.target.value.length <= 0) {
+    passwordErrorCheck.textContent = '비밀번호를 입력해 주세요.';
+    e.target.classList.add('inputError');
+    isValid[2] = false;
+  } else if (
+    e.target.value.length < 8 ||
+    !/\d/.test(e.target.value) ||
+    !/[a-zA-Z]/.test(e.target.value)
+  ) {
+    passwordErrorCheck.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+    e.target.classList.add('inputError');
+    isValid[2] = false;
+  } else if (passwordCheck.value !== e.target.value) {
     passwordErrorCheck.textContent = '비밀번호가 일치하지 않아요.';
     e.target.classList.add('inputError');
+    isValid[2] = false;
   } else {
     passwordErrorCheck.textContent = '';
     e.target.classList.remove('inputError');
+    isValid[2] = true;
   }
 };
+
+form.addEventListener('submit', onSubmit);
 
 email.addEventListener('focusout', emailInputCheck);
 

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -1,0 +1,63 @@
+import {
+  form,
+  email,
+  emailError,
+  eyeIcon,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  isEmail,
+  removeEmpty,
+} from '../src/common/sign.js';
+
+const passwordCheck = document.querySelector('.password_check');
+const passwordReCheck = document.querySelector('.password_recheck');
+
+const passwordError = document.querySelector('.password-error');
+const passwordErrorCheck = document.querySelector('.password-error-check');
+
+const emailInputCheck = (e) => {
+  e.target.value = removeEmpty(e.target.value);
+
+  if (e.target.value.length <= 0) {
+    emailError.textContent = '이메일을 입력해 주세요.';
+    e.target.classList.add('inputError');
+  } else if (!isEmail(email.value)) {
+    emailError.textContent = '올바른 이메일 주소가 아닙니다.';
+    e.target.classList.add('inputError');
+  } else if (e.target.value === TEST_EMAIL) {
+    emailError.textContent = '이미 사용 중인 이메일입니다.';
+  } else {
+    emailError.textContent = '';
+    e.target.classList.remove('inputError');
+  }
+};
+
+const passwordInputCheck = (e) => {
+  e.target.value = removeEmpty(e.target.value);
+
+  if (e.target.value.length < 8 || !/\d/.test(e.target.value) || !/[a-zA-Z]/.test(e.target.value)) {
+    passwordError.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+    e.target.classList.add('inputError');
+  } else {
+    passwordError.textContent = '';
+    e.target.classList.remove('inputError');
+  }
+};
+
+const passwordInputRecheck = (e) => {
+  e.target.value = removeEmpty(e.target.value);
+
+  if (passwordCheck.value !== e.target.value) {
+    passwordErrorCheck.textContent = '비밀번호가 일치하지 않아요.';
+    e.target.classList.add('inputError');
+  } else {
+    passwordErrorCheck.textContent = '';
+    e.target.classList.remove('inputError');
+  }
+};
+
+email.addEventListener('focusout', emailInputCheck);
+
+passwordCheck.addEventListener('focusout', passwordInputCheck);
+
+passwordReCheck.addEventListener('focusout', passwordInputRecheck);

--- a/signup/signup.js
+++ b/signup/signup.js
@@ -2,17 +2,18 @@ import {
   form,
   email,
   emailError,
+  passwordError,
   eyeIcon,
   TEST_EMAIL,
-  TEST_PASSWORD,
   isEmail,
   removeEmpty,
+  eyeIconOn,
+  eyeIconOff,
 } from '../src/common/sign.js';
 
 const passwordCheck = document.querySelector('.password_check');
 const passwordReCheck = document.querySelector('.password_recheck');
 
-const passwordError = document.querySelector('.password-error');
 const passwordErrorCheck = document.querySelector('.password-error-check');
 
 let isValid = [false, false, false];
@@ -20,10 +21,17 @@ let isValid = [false, false, false];
 const onSubmit = (e) => {
   e.preventDefault();
 
-  if (isValid[0] === false) emailError.textContent = '이메일을 확인해 주세요.';
-  if (isValid[1] === false) passwordError.textContent = '비밀번호를 확인해 주세요.';
-  if (isValid[2] === false) passwordErrorCheck.textContent = '비밀번호를 확인해 주세요.';
-  else location.href = '/folder/folder.html';
+  if (isValid[0] === false) {
+    emailError.textContent = '이메일을 확인해 주세요.';
+  }
+  if (isValid[1] === false) {
+    passwordError.textContent = '비밀번호를 확인해 주세요.';
+  }
+  if (isValid[2] === false) {
+    passwordErrorCheck.textContent = '비밀번호를 확인해 주세요.';
+  } else if (isValid.includes(false) === false) {
+    location.href = '/folder/folder.html';
+  }
 };
 
 const emailInputCheck = (e) => {
@@ -95,10 +103,50 @@ const passwordInputRecheck = (e) => {
   }
 };
 
-form.addEventListener('submit', onSubmit);
+const togglePasswordVisibility1 = () => {
+  if (passwordCheck.type === 'password') {
+    passwordCheck.type = 'text';
+    eyeIconOff[0].style.display = 'none';
+    eyeIconOn[0].style.display = 'inline-block';
+  } else {
+    passwordCheck.type = 'password';
+    eyeIconOff[0].style.display = 'inline-block';
+    eyeIconOn[0].style.display = 'none';
+  }
+};
+
+const togglePasswordVisibility2 = () => {
+  if (passwordReCheck.type === 'password') {
+    passwordReCheck.type = 'text';
+    eyeIconOff[1].style.display = 'none';
+    eyeIconOn[1].style.display = 'inline-block';
+  } else {
+    passwordReCheck.type = 'password';
+    eyeIconOff[1].style.display = 'inline-block';
+    eyeIconOn[1].style.display = 'none';
+  }
+};
+
+const eyeIconClick1 = (e) => {
+  if (e.target.classList.contains('eye-icon')) {
+    togglePasswordVisibility1();
+  }
+};
+
+const eyeIconClick2 = (e) => {
+  if (e.target.classList.contains('eye-icon')) {
+    togglePasswordVisibility2();
+  }
+};
 
 email.addEventListener('focusout', emailInputCheck);
 
 passwordCheck.addEventListener('focusout', passwordInputCheck);
 
 passwordReCheck.addEventListener('focusout', passwordInputRecheck);
+
+eyeIcon[0].addEventListener('click', eyeIconClick1);
+
+eyeIcon[1].addEventListener('click', eyeIconClick2);
+
+form.addEventListener('submit', onSubmit);

--- a/src/common/sign.js
+++ b/src/common/sign.js
@@ -1,0 +1,6 @@
+export const isEmail = (asValue) => {
+  let regExp =
+    /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
+
+  return regExp.test(asValue);
+};

--- a/src/common/sign.js
+++ b/src/common/sign.js
@@ -3,10 +3,11 @@ const form = document.querySelector('form');
 const email = document.querySelector('#email');
 
 const emailError = document.querySelector('.email-error');
+const passwordError = document.querySelector('.password-error');
 
-const eyeIcon = document.querySelector('.icon');
-const eyeIconOn = document.querySelector('.eye-icon-on');
-const eyeIconOff = document.querySelector('.eye-icon-off');
+const eyeIcon = document.querySelectorAll('.icon');
+const eyeIconOn = document.querySelectorAll('.eye-icon-on');
+const eyeIconOff = document.querySelectorAll('.eye-icon-off');
 
 const TEST_EMAIL = 'test@codeit.com';
 const TEST_PASSWORD = 'codeit101';
@@ -26,6 +27,7 @@ export {
   form,
   email,
   emailError,
+  passwordError,
   eyeIcon,
   eyeIconOn,
   eyeIconOff,

--- a/src/common/sign.js
+++ b/src/common/sign.js
@@ -1,6 +1,36 @@
-export const isEmail = (asValue) => {
+const form = document.querySelector('form');
+
+const email = document.querySelector('#email');
+
+const emailError = document.querySelector('.email-error');
+
+const eyeIcon = document.querySelector('.icon');
+const eyeIconOn = document.querySelector('.eye-icon-on');
+const eyeIconOff = document.querySelector('.eye-icon-off');
+
+const TEST_EMAIL = 'test@codeit.com';
+const TEST_PASSWORD = 'codeit101';
+
+const isEmail = (asValue) => {
   let regExp =
     /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
 
   return regExp.test(asValue);
+};
+
+const removeEmpty = (input) => {
+  return input.replace(/(\s*)/g, '');
+};
+
+export {
+  form,
+  email,
+  emailError,
+  eyeIcon,
+  eyeIconOn,
+  eyeIconOff,
+  TEST_EMAIL,
+  TEST_PASSWORD,
+  isEmail,
+  removeEmpty,
 };


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  회원가입 페이지의 이메일, 비밀번호, 비밀번호 확인 input에 필요한 유효성 검증 함수를 만들고 적용해 주세요.
- [x]  React와 같은 UI 라이브러리를 사용하지 않고 진행합니다.
- [x]  이메일 input에서 focus out 할 때, 값이 없을 경우 “이메일을 입력해주세요.” 에러 메세지를 보입니다.
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 “올바른 이메일 주소가 아닙니다.” 에러 메세지를 보입니다.
- [x]  이메일 input에서 focus out 할 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우, “이미 사용 중인 이메일입니다.” 에러 메세지를 보입니다.
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 에러 메세지를 보입니다.
- [x]  비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않아요.” 에러 메세지를 보입니다.
- [x]  회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지로 알립니다.
- [x]  이외의 유효한 회원가입 시도의 경우, “/folder”로 이동합니다.
- [x]  회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 실행돼야 합니다.

### 심화

- [x]  비밀번호를 확인할 수 있는 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 합니다.
- [x]  로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용해 주세요.

## 주요 변경사항

- 회원가입에서 비밀번호 눈 아이콘 클릭 시 비밀번호 확인 기능
- 회원가입 이메일, 비밀번호 잘못된 입력 시 에러 메세지 출력
- 유효한 회원가입 시도의 경우, 지정된 페이지로 이동

## 스크린샷

netlify 배포 url
- https://linkbrary-28.netlify.app/

## 멘토에게

- 저번 코드리뷰에서 말씀해주셨던 Layout Shift 발생과 관련하여 아직 공부 중입니다. 이해하기 조금 어려워서 시간이 걸리네요..
- 공통된 로직을 모듈로 분리하는 과정에서 어떻게 손을 대야할 지 아직은 감이 잡히지 않습니다. 이후에도 계속 리팩토링 할 예정입니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
