### PR TITLE
[소남주] Week5

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -24,7 +24,7 @@
     </header>
 
     <div class="login_form">
-      <form id="signin-form" action="/folder" method="post" onsubmit="return false">
+      <form id="signin-form" action="/folder" method="get" onsubmit="return false">
         <div>
           <label for="login-email">이메일</label>
           <input id="login-email" class="login-email" type="email" placeholder="이메일을 입력해주세요.">
@@ -36,7 +36,7 @@
           <div class="error_message"></div>
         </div>
 
-        <button type="submit" id="login-button" href="#">
+        <button type="submit" id="login-button">
           로그인
         </button>
       </form>

--- a/login/index.html
+++ b/login/index.html
@@ -24,30 +24,30 @@
     </header>
 
     <div class="login_form">
-      <form>
+      <form id="signin-form" action="/folder" method="post" onsubmit="return false">
         <div>
           <label for="login-email">이메일</label>
-          <input id="login-email" class="login-email" type="email">
+          <input id="login-email" class="login-email" type="email" placeholder="이메일을 입력해주세요.">
           <div class="error_message"></div>
         </div>
         <div>
           <label for="login-password">비밀번호</label>
-          <input id="login-password" class="login-password" type="password">
+          <input id="login-password" class="login-password" type="password" placeholder="비밀번호를 입력해주세요.">
           <div class="error_message"></div>
         </div>
+
+        <button type="submit" id="login-button" href="#">
+          로그인
+        </button>
       </form>
     </div>
-
-    <a id="login-button" class="link_login" href="#">
-      로그인
-    </a>
   </div>
 
   <div class="sns_login">
     소셜 로그인
     <div class="button_sns">
       <a class="image_google" href="http://www.google.com/">
-        <img class="image_background" src="/images/google_background.svg">
+        <img class="image_background" src="/images/google_background.svg">  <!--TODO: css로 수정 예정-->
         <img class="image_icon" src="/images/google_icon.png">
       </a>
       <a class="image_kakaotalk" href="http://www.kakaocorp.com/page/">

--- a/login/index.js
+++ b/login/index.js
@@ -1,14 +1,11 @@
 const INPUT_EMAIL = document.querySelector('#login-email');
 const INPUT_PASSWORD = document.querySelector('#login-password');
-const LOGIN_BUTTON = document.querySelector('#login-button');
 const FORM_ELEMENT = document.querySelector('#signin-form');
 
 INPUT_EMAIL.addEventListener('focusout', handleFocusOut);
 INPUT_EMAIL.addEventListener('focusout', emailCheck);
 
 INPUT_PASSWORD.addEventListener('focusout', handleFocusOut);
-
-// LOGIN_BUTTON.addEventListener('click', handleSubmit);
 
 FORM_ELEMENT.addEventListener('submit', handleSubmit)
 
@@ -50,7 +47,7 @@ function emailCheck(e) {
 
 
 // 이메일, 비밀번호 일치 시 페이지 이동
-function handleSubmit(e) {  // FIXME: 입력 정보 일치 시 HTML ERROR 405 발생
+function handleSubmit(e) {
   if (INPUT_EMAIL.value === 'test@codeit.com' && INPUT_PASSWORD.value === 'codeit101') {
     FORM_ELEMENT.submit();
   } 

--- a/login/index.js
+++ b/login/index.js
@@ -16,13 +16,12 @@ function handleFocusOut(e) {
 
     if (e.target.classList.contains('login-email')) {
       e.target.nextElementSibling.textContent = '이메일을 입력해 주세요.';
+      e.target.classList.add('input_error');
     }
     else if (e.target.classList.contains('login-password')) {
       e.target.nextElementSibling.textContent = '비밀번호를 입력해 주세요.';
+      e.target.classList.add('input_error');
     }
-
-    e.target.classList.add('input_error');
-
   }
 }
 

--- a/login/index.js
+++ b/login/index.js
@@ -1,29 +1,30 @@
-const inputEmail = document.querySelector('#login-email');
-const inputPassword = document.querySelector('#login-password');
-const loginButton = document.querySelector('#login-button');
+const INPUT_EMAIL = document.querySelector('#login-email');
+const INPUT_PASSWORD = document.querySelector('#login-password');
+const LOGIN_BUTTON = document.querySelector('#login-button');
+const FORM_ELEMENT = document.querySelector('#signin-form');
 
-inputEmail.addEventListener('focusout', noInput);
-inputEmail.addEventListener('focusout', emailCheck);
-inputEmail.addEventListener('keyup', enterKey);
+INPUT_EMAIL.addEventListener('focusout', handleFocusOut);
+INPUT_EMAIL.addEventListener('focusout', emailCheck);
 
-inputPassword.addEventListener('focusout', noInput);
-inputPassword.addEventListener('keyup', enterKey);
+INPUT_PASSWORD.addEventListener('focusout', handleFocusOut);
 
-loginButton.addEventListener('click', correctInput);
+// LOGIN_BUTTON.addEventListener('click', handleSubmit);
+
+FORM_ELEMENT.addEventListener('submit', handleSubmit)
 
 
 // input 없을 때 에러 메세지
-function noInput(e) {
+function handleFocusOut(e) {
   if (e.target.value === '') {
 
     if (e.target.classList.contains('login-email')) {
       e.target.nextElementSibling.textContent = '이메일을 입력해 주세요.';
-      e.target.style.border = '1px solid #FF5B56';
     }
     else if (e.target.classList.contains('login-password')) {
       e.target.nextElementSibling.textContent = '비밀번호를 입력해 주세요.';
-      e.target.style.border = '1px solid #FF5B56';
     }
+
+    e.target.classList.add('input_error');
 
   }
 }
@@ -31,13 +32,9 @@ function noInput(e) {
 
 // 이메일 유효성 확인
 function emailValidation(input) {
-  let reg_email = /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
+  const REG_EMAIL = /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
 
-  if (!reg_email.test(input)) {
-    return false;
-  } else {
-    return true;
-  }
+  return REG_EMAIL.test(input);
 }
 
 function emailCheck(e) {
@@ -45,7 +42,7 @@ function emailCheck(e) {
 
     if (!emailValidation(e.target.value)) {
       e.target.nextElementSibling.textContent = '올바른 이메일 주소가 아닙니다.';
-      e.target.style.border = '1px solid #FF5B56';
+      e.target.classList.add('input_error');
     }
 
   }
@@ -53,20 +50,14 @@ function emailCheck(e) {
 
 
 // 이메일, 비밀번호 일치 시 페이지 이동
-function correctInput(e) {
-  if (inputEmail.value === 'test@codeit.com' && inputPassword.value === 'codeit101') {
-    window.location.href = "/folder";
+function handleSubmit(e) {  // FIXME: 입력 정보 일치 시 HTML ERROR 405 발생
+  if (INPUT_EMAIL.value === 'test@codeit.com' && INPUT_PASSWORD.value === 'codeit101') {
+    FORM_ELEMENT.submit();
   } 
   else {
-    inputEmail.nextElementSibling.textContent = '이메일을 확인해 주세요.';
-    inputEmail.style.border = '1px solid #FF5B56';
-    inputPassword.nextElementSibling.textContent = '비밀번호를 확인해 주세요.';
-    inputPassword.style.border = '1px solid #FF5B56';
+    INPUT_EMAIL.nextElementSibling.textContent = '이메일을 확인해 주세요.';
+    INPUT_EMAIL.classList.add('input_error');
+    INPUT_PASSWORD.nextElementSibling.textContent = '비밀번호를 확인해 주세요.';
+    INPUT_PASSWORD.classList.add('input_error');
   }
 }
-
-function enterKey(e) {
-  if (e.keyCode === 13) {
-    correctInput();
-  }
-} 

--- a/login/login_style.css
+++ b/login/login_style.css
@@ -84,7 +84,8 @@ header {
   line-height: normal;
 }
 
-.login_form input {
+.login-email,
+.login-password {
   position: relative;
 
   border: 1px solid #373740;
@@ -112,7 +113,8 @@ header {
   font-weight: 400;
 }
 
-.link_login {
+#login-button {
+  border: none;
   border-radius: 8px;
   padding: 16px 20px;
   background: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
@@ -201,4 +203,11 @@ header {
     width: 100%;
     max-width: 400px;
   }
+}
+
+
+/* 이벤트 관련 */
+
+.input_error {
+  border: 1px solid #FF5B56;
 }

--- a/signup/index.html
+++ b/signup/index.html
@@ -23,26 +23,29 @@
       </div>
     </div>
 
-    <div class="login_form">
-      <form>
+    <div class="signup_form">
+      <form id="signup-form" action="/folder" method="get" onsubmit="return false">
         <div>
-          <label for="login-email">이메일</label>
-          <input id="login-email" type="email">
+          <label for="signup-email">이메일</label>
+          <input id="signup-email" class="signup-email" type="email" placeholder="이메일을 입력해주세요.">
+          <div class="error_message"></div>
         </div>
         <div>
-          <label for="login-password">비밀번호</label>
-          <input id="login-password" type="password">
+          <label for="signup-password">비밀번호</label>
+          <input id="signup-password" class="signup-password" type="password" placeholder="비밀번호를 입력해주세요.">
+          <div class="error_message"></div>
         </div>
         <div>
           <label for="check-password">비밀번호 확인</label>
-          <input id="check-password" type="password">
+          <input id="check-password" class="check-password" type="password" placeholder="비밀번호를 입력해주세요.">
+          <div class="error_message"></div>
         </div>
+        
+        <button type="submit" id="signup-button">
+          회원가입
+        </button>
       </form>
     </div>
-
-    <a class="link_login" href="#">
-      회원가입
-    </a>
   </div>
 
   <div class="sns_login">
@@ -58,5 +61,7 @@
       </a>
     </div>
   </div>
+
+  <script src="./index.js"></script>
 </body>
 </html>

--- a/signup/index.html
+++ b/signup/index.html
@@ -49,7 +49,7 @@
     다른 방식으로 가입하기
     <div class="button_sns">
       <a class="image_google" href="http://www.google.com/">
-        <img class="image_background" src="/images/google_background.svg"> <!--추후 css로 수정 예정-->
+        <img class="image_background" src="/images/google_background.svg"> <!--TODO: css로 수정 예정-->
         <img class="image_icon" src="/images/google_icon.png">
       </a>
       <a class="image_kakaotalk" href="http://www.kakaocorp.com/page/">

--- a/signup/index.js
+++ b/signup/index.js
@@ -1,53 +1,38 @@
 const INPUT_EMAIL = document.querySelector('#signup-email');
 const INPUT_PASSWORD = document.querySelector('#signup-password');
 const INPUT_PASSWORD_CHECK = document.querySelector('#check-password')
+const ERROR_MESSAGE = document.querySelector('.error_message');
 const FORM_ELEMENT = document.querySelector('#signup-form');
 
-INPUT_EMAIL.addEventListener('focusout', handleFocusOut);
-INPUT_EMAIL.addEventListener('focusout', emailCheck);
-
-INPUT_PASSWORD.addEventListener('focusout', handleFocusOut);
-INPUT_PASSWORD.addEventListener('focusout', passwordCheck);
-
-INPUT_PASSWORD_CHECK.addEventListener('focusout', samePasswordCheck);
-
-
-// input 없을 때 에러 메세지
-function handleFocusOut(e) {
-  if (e.target.value === '') {
-
-    if (e.target.classList.contains('signup-email')) {
-      e.target.nextElementSibling.textContent = '이메일을 입력해 주세요.';
-    }
-    else if (e.target.classList.contains('signup-password')) {
-      e.target.nextElementSibling.textContent = '비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.';
-    }
-
-    e.target.classList.add('input_error');
-
-  }
-}
+INPUT_EMAIL.addEventListener('focusout', handleEmailFocusout);
+INPUT_PASSWORD.addEventListener('focusout', handlePasswordFocusout);
+INPUT_PASSWORD_CHECK.addEventListener('focusout', handlePasswordCheckFocusout);
+FORM_ELEMENT.addEventListener('submit', handleSubmit);
 
 
 // 이메일 유효성 확인
 function emailValidation(input) {
   const REG_EMAIL = /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
-
   return REG_EMAIL.test(input);
 }
 
-function emailCheck(e) {
-  if (INPUT_EMAIL.value !== '') {
-
-    if (INPUT_EMAIL.value === 'test@codeit.com') {
-      INPUT_EMAIL.nextElementSibling.textContent = '이미 사용 중인 이메일입니다.';
-
-    } else if (!emailValidation(INPUT_EMAIL.value)) {
-      INPUT_EMAIL.nextElementSibling.textContent = '올바른 이메일 주소가 아닙니다.';
-    }
-
+function handleEmailFocusout(e) {
+  if (INPUT_EMAIL.value === '') {
+    INPUT_EMAIL.nextElementSibling.textContent = '이메일을 입력해 주세요.';
     INPUT_EMAIL.classList.add('input_error');
 
+    return false;
+
+  } else if (INPUT_EMAIL.value !== '') {
+    if (INPUT_EMAIL.value === 'test@codeit.com') {
+      INPUT_EMAIL.nextElementSibling.textContent = '이미 사용 중인 이메일입니다.';
+      INPUT_EMAIL.classList.add('input_error');
+      return false;
+    } else if (!emailValidation(INPUT_EMAIL.value)) {
+      INPUT_EMAIL.nextElementSibling.textContent = '올바른 이메일 주소가 아닙니다.';
+      INPUT_EMAIL.classList.add('input_error');
+      return false;
+    }
   }
 }
 
@@ -55,20 +40,48 @@ function emailCheck(e) {
 // 비밀번호 유효성 확인
 function passwordValidation(input) {
   const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
-
   return REG_PASSWORD.test(input);
 }
 
-function passwordCheck(e) {
+function handlePasswordFocusout(e) {
   if (!passwordValidation(INPUT_PASSWORD.value)) {
     INPUT_PASSWORD.nextElementSibling.textContent = '비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.';
-    e.target.classList.add('input_error');
+    INPUT_PASSWORD.classList.add('input_error');
+
+    return false;
   }
 }
 
-function samePasswordCheck(e) {
+function handlePasswordCheckFocusout(e) {
   if (INPUT_PASSWORD.value !== INPUT_PASSWORD_CHECK.value) {
     INPUT_PASSWORD_CHECK.nextElementSibling.textContent = '비밀번호가 일치하지 않아요.';
-    e.target.classList.add('input_error');
+    INPUT_PASSWORD_CHECK.classList.add('input_error');
+
+    return false;
   }
 }
+
+
+// 회원 가입 실행 시 유효성 확인
+let checkFunctions = [
+  handleEmailFocusout,
+  handlePasswordFocusout,
+  handlePasswordCheckFocusout
+]
+
+function handleSubmit(e) {
+  let count = 0;
+  console.log(count);
+
+  for (let checkFunction of checkFunctions) {
+    if (checkFunction(e) === false) {
+      checkFunction(e);
+      count++;
+    }
+  }
+  console.log(count);
+
+  if (count === 0) {
+    FORM_ELEMENT.submit();
+  }
+} 

--- a/signup/index.js
+++ b/signup/index.js
@@ -1,0 +1,74 @@
+const INPUT_EMAIL = document.querySelector('#signup-email');
+const INPUT_PASSWORD = document.querySelector('#signup-password');
+const INPUT_PASSWORD_CHECK = document.querySelector('#check-password')
+const FORM_ELEMENT = document.querySelector('#signup-form');
+
+INPUT_EMAIL.addEventListener('focusout', handleFocusOut);
+INPUT_EMAIL.addEventListener('focusout', emailCheck);
+
+INPUT_PASSWORD.addEventListener('focusout', handleFocusOut);
+INPUT_PASSWORD.addEventListener('focusout', passwordCheck);
+
+INPUT_PASSWORD_CHECK.addEventListener('focusout', samePasswordCheck);
+
+
+// input 없을 때 에러 메세지
+function handleFocusOut(e) {
+  if (e.target.value === '') {
+
+    if (e.target.classList.contains('signup-email')) {
+      e.target.nextElementSibling.textContent = '이메일을 입력해 주세요.';
+    }
+    else if (e.target.classList.contains('signup-password')) {
+      e.target.nextElementSibling.textContent = '비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.';
+    }
+
+    e.target.classList.add('input_error');
+
+  }
+}
+
+
+// 이메일 유효성 확인
+function emailValidation(input) {
+  const REG_EMAIL = /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
+
+  return REG_EMAIL.test(input);
+}
+
+function emailCheck(e) {
+  if (INPUT_EMAIL.value !== '') {
+
+    if (INPUT_EMAIL.value === 'test@codeit.com') {
+      INPUT_EMAIL.nextElementSibling.textContent = '이미 사용 중인 이메일입니다.';
+
+    } else if (!emailValidation(INPUT_EMAIL.value)) {
+      INPUT_EMAIL.nextElementSibling.textContent = '올바른 이메일 주소가 아닙니다.';
+    }
+
+    INPUT_EMAIL.classList.add('input_error');
+
+  }
+}
+
+
+// 비밀번호 유효성 확인
+function passwordValidation(input) {
+  const REG_PASSWORD = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+
+  return REG_PASSWORD.test(input);
+}
+
+function passwordCheck(e) {
+  if (!passwordValidation(INPUT_PASSWORD.value)) {
+    INPUT_PASSWORD.nextElementSibling.textContent = '비밀번호는 영문,숫자 조합 8자 이상 입력해주세요.';
+    e.target.classList.add('input_error');
+  }
+}
+
+function samePasswordCheck(e) {
+  if (INPUT_PASSWORD.value !== INPUT_PASSWORD_CHECK.value) {
+    INPUT_PASSWORD_CHECK.nextElementSibling.textContent = '비밀번호가 일치하지 않아요.';
+    e.target.classList.add('input_error');
+  }
+}

--- a/signup/signup_style.css
+++ b/signup/signup_style.css
@@ -53,26 +53,26 @@ body {
   cursor: pointer;
 }
 
-.login_form {
+.signup_form {
   display: flex;
   justify-content: center;
 }
 
-form {
+.signup_form form {
   display: flex;
   flex-direction: column;
   width: 400px;
   gap: 24px;
 }
 
-form > div {
+.signup_form form > div {
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
-.login_form label {
+.signup_form label {
   color: #000000;
   font-family: Pretendard;
   font-size: 14px;
@@ -81,7 +81,9 @@ form > div {
   line-height: normal;
 }
 
-.login_form input {
+.signup-email,
+.signup-password,
+.check-password {
   position: relative;
 
   border: 1px solid #373740;
@@ -97,12 +99,20 @@ form > div {
   line-height: 24px;
 }
 
-input:focus {
+#signup-form input:focus {
   border: 1px solid #6D6AFE;
   outline: none;
 }
 
-.link_login {
+.error_message {
+  color: #FF5B56;
+  font-family: Pretendard;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+#signup-button {
+  border: none;
   border-radius: 8px;
   padding: 16px 20px;
   background: linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%);
@@ -191,4 +201,11 @@ input:focus {
     width: 100%;
     max-width: 400px;
   }
+}
+
+
+/* 이벤트 관련 */
+
+.input_error {
+  border: 1px solid #FF5B56;
 }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [ ] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 피드백 내용 반영
- 5주차 기본 요구사항 반영

## 스크린샷

- 배포 웹 링크 : https://celadon-crostata-037659.netlify.app/
- Figma 링크 : https://www.figma.com/file/A7PPL7WOzACZepg9bMQRMd/Weekly-Mission%5B4%EA%B8%B0%5D?node-id=2%3A7940&mode=dev

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
