### PR TITLE
[권나은] week5

### DIFF
--- a/commonChange_input.js
+++ b/commonChange_input.js
@@ -1,0 +1,51 @@
+//이메일 입력 확인
+export function emailHandleInputFocusOut(inputElement, errorElement) {
+  // focusout 이벤트가 발생했을 때 실행되는 코드
+  if (!inputElement.value) {
+    errorElement.textContent = '이메일을 입력해 주세요.';
+    errorElement.style.display = 'block';
+    inputElement.style.borderColor = '#FF5B56'; // 테두리 색상 변경
+  } else if(!isValidEmail(inputElement.value)) {
+    errorElement.textContent = '올바른 이메일 주소가 아닙니다.';
+    errorElement.style.display = 'block';
+    inputElement.style.borderColor = '#FF5B56'; // 테두리 색상 변경  
+  } else {
+    noError(inputElement, errorElement);
+  }
+}
+
+//비밀번호 입력 확인
+export function passwordHandleFocusOut(inputElement, errorElement) {
+  if (!inputElement.value) {
+    errorElement.textContent = '비밀번호를 입력해 주세요.';
+    errorElement.style.display = 'block';
+    inputElement.style.borderColor = '#FF5B56'; 
+  } else {
+    noError(inputElement, errorElement);
+  }
+}
+
+export function isValidEmail(email) {
+  // 간단한 이메일 유효성 검사를 위한 정규 표현식 사용
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
+
+//아이콘 변경
+export function togglePasswordType(passwordInput,passwordIcon) {
+  if (passwordInput.type === 'password') {
+    passwordInput.type = 'text';
+    passwordIcon.classList.remove('fa-eye');
+    passwordIcon.classList.add('fa-eye-slash');
+  } else {
+    passwordInput.type = 'password';
+    passwordIcon.classList.remove('fa-eye-slash');
+    passwordIcon.classList.add('fa-eye');
+  }
+}
+
+export const noError = (inputElement,errorElement) => {
+  errorElement.style.display = 'none';
+  errorElement.textContent = '';
+  inputElement.style.borderColor = '#CCD5E3';
+}

--- a/login.js
+++ b/login.js
@@ -1,0 +1,58 @@
+import * as input from './commonChange_input.js';
+
+const loginEmailInput = document.querySelector('#login__email-form');
+const loginPwInput = document.querySelector('#login__password-form');
+const loginEmailError = document.querySelector('.login__email-form--error');
+const loginPwError = document.querySelector('.login__password-form--error');
+
+const loginButton = document.querySelector('.login__info--loginBt');
+const loginPasswordIcon = document.querySelector('.password__toggle-icon');
+
+loginEmailInput.addEventListener('focusout', loginEmailFocusOut);
+loginPwInput.addEventListener('focusout', loginpwFocusOut);
+loginPasswordIcon.addEventListener('click', passwordToggleIcon);
+loginButton.addEventListener('click', handleLoginButtonClick);
+loginEmailInput.addEventListener('keyup',handleLoginButtonEnter);
+loginPwInput.addEventListener('keyup',handleLoginButtonEnter);
+
+//이메일 입력 확인
+function loginEmailFocusOut(event) {
+  input.emailHandleInputFocusOut(loginEmailInput,loginEmailError);
+}
+
+//비밀번호 확인
+function loginpwFocusOut(event) {
+  input.passwordHandleFocusOut(loginPwInput,loginPwError);
+}
+
+//비밀번호 아이콘 및 타입 변경
+function passwordToggleIcon(event) {
+  input.togglePasswordType(loginPwInput,loginPasswordIcon);
+}
+
+//엔터키
+function handleLoginButtonEnter(event) {
+  if (event.code === 'Enter') {
+    handleLoginButtonClick();
+  } 
+}
+
+//로그인 버튼 클릭 시
+function handleLoginButtonClick(event) {
+  if (loginEmailInput.value === 'test@codeit.com' && loginPwInput.value === 'codeit101') {
+    window.location.href = "/folder";
+  }
+  else {
+    loginCheck();
+  }
+}
+
+//이메일 비밀번호가 틀렸을 때
+const loginCheck = () => {
+  loginPwError.textContent = '비밀번호를 확인해 주세요.';
+  loginPwError.style.display = 'block';
+  loginPwInput.style.borderColor = '#FF5B56'; 
+  loginEmailError.textContent = '이메일을 확인해 주세요.';
+  loginEmailError.style.display = 'block';
+  loginEmailInput.style.borderColor = '#FF5B56'; 
+}

--- a/signup.css
+++ b/signup.css
@@ -91,7 +91,6 @@ html {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 12px;
   width: 100%;
 }
 
@@ -104,6 +103,7 @@ html {
   border-radius: 8px;
   border: 1px solid var(--Linkbrary-gray20, #CCD5E3);
   background: var(--Linkbrary-white, #FFF);
+  margin-top: 12px;
 }
 
 .signup__form--inputbox input:focus {
@@ -131,10 +131,22 @@ html {
   width: 100%;
 }
 
-.fa-eye {
+.password__toggle-icon,
+.pwcheck__toggle-icon {
   position: absolute;
   right: 15px;
   top: 18px;
+}
+
+
+.signup__email-form--error,
+.signup__password-form--error,
+.signup__pwcheck-form--error {
+  display: none;
+  color: #FF5B56;
+  font-size: 14px;
+  font-weight: 400;
+  margin-top: 6px;
 }
 
 /* 하단 부분 */

--- a/signup.html
+++ b/signup.html
@@ -12,85 +12,91 @@
 </head>
 
 <body>
-  <section class="signup">
-    <article class="signup__container">
-      <div class="signup__logoSection">
-        <a class="signup_logoSection--logo" href="/">
-          <svg xmlns="http://www.w3.org/2000/svg" width="133" height="24" viewBox="0 0 133 24" fill="none">
-            <path d="M5.20583 15.7049V0.792232H0V20.2718H14.9638V15.7049H5.20583Z" fill="#6D6AFE" />
-            <path d="M21.6801 20.2718V5.12621H16.4743V20.2718H21.6801ZM21.6801 3.96117V0H16.4743V3.96117H21.6801Z"
-              fill="#6D6AFE" />
-            <path
-              d="M33.1713 4.66019C31.117 4.66019 29.5062 5.42913 28.409 6.71068V5.12621H23.2032V20.2718H28.409V13.4913C28.4557 10.5786 29.7397 9.34369 31.8407 9.34369C33.6382 9.34369 34.3385 10.2524 34.3385 12.4194V20.2718H39.5444V11.5107C39.5444 6.92039 37.8169 4.66019 33.1713 4.66019Z"
-              fill="#6D6AFE" />
-            <path
-              d="M46.0405 10.0893V0H40.8347V20.2718H46.0405V16.7068L48.2116 14.167L50.7328 20.2718H56.4755L53.184 12.233H49.869L56.0087 5.12621H50.3359L46.0405 10.0893Z"
-              fill="#6D6AFE" />
-            <path
-              d="M67.0849 20.7379C70.2364 20.7379 74.1116 18.9437 74.1116 12.699C74.1116 6.45437 70.2364 4.66019 67.0849 4.66019C65.3341 4.66019 63.77 5.17281 62.5094 6.03495V0H57.3035V20.2718H62.5094V19.3631C63.77 20.2485 65.3341 20.7379 67.0849 20.7379ZM65.7076 16.1942C63.91 16.1942 62.5094 15.2854 62.5094 12.699V12.5126C62.5794 10.0893 63.9567 9.20388 65.7076 9.20388C67.7152 9.20388 68.9058 10.2524 68.9058 12.699C68.9058 15.1689 67.7152 16.1942 65.7076 16.1942Z"
-              fill="#6D6AFE" />
-            <path
-              d="M74.935 20.2718H80.1409V13.9573C80.1876 11.0214 81.5182 9.32039 86.1638 9.32039V4.66019C83.3624 4.66019 81.3781 5.63883 80.1409 7.1068V5.12621H74.935V20.2718Z"
-              fill="#6D6AFE" />
-            <path
-              d="M93.541 20.7379C95.2685 20.7379 96.8559 20.2485 98.1165 19.3631V20.2718H103.322V5.12621H98.1165V6.03495C96.8559 5.17281 95.2685 4.66019 93.541 4.66019C90.3895 4.66019 86.5143 6.45437 86.5143 12.699C86.5143 18.9437 90.3895 20.7379 93.541 20.7379ZM94.9183 16.1942C92.9107 16.1942 91.7201 15.1689 91.7201 12.699C91.7201 10.2524 92.9107 9.20388 94.9183 9.20388C96.7159 9.20388 98.1165 10.1359 98.1165 12.699C98.1165 15.2854 96.7159 16.1942 94.9183 16.1942Z"
-              fill="#6D6AFE" />
-            <path
-              d="M104.613 20.2718H109.819V13.9573C109.865 11.0214 111.196 9.32039 115.841 9.32039V4.66019C113.04 4.66019 111.056 5.63883 109.819 7.1068V5.12621H104.613V20.2718Z"
-              fill="#6D6AFE" />
-            <path
-              d="M127.794 5.12621V11.7204C127.234 12.3495 126.23 12.6058 125.063 12.6058C122.588 12.6058 121.865 11.8369 121.865 10.4155V5.12621H116.659V10.7883C116.659 14.9359 119.6 17.1728 123.686 17.1728C125.203 17.1728 126.604 16.8466 127.794 16.2874V16.8466C127.794 18.9204 127 19.666 124.946 19.666C123.242 19.666 122.425 19.1534 122.191 17.965H116.962C117.383 22.2524 119.694 24 124.946 24C130.666 24 133 21.9029 133 16.4505V5.12621H127.794Z"
-              fill="#6D6AFE" />
-          </svg>
-        </a>
+  <main>
+    <section class="signup">
+      <article class="signup__container">
+        <div class="signup__logoSection">
+          <a class="signup_logoSection--logo" href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" width="133" height="24" viewBox="0 0 133 24" fill="none">
+              <path d="M5.20583 15.7049V0.792232H0V20.2718H14.9638V15.7049H5.20583Z" fill="#6D6AFE" />
+              <path d="M21.6801 20.2718V5.12621H16.4743V20.2718H21.6801ZM21.6801 3.96117V0H16.4743V3.96117H21.6801Z"
+                fill="#6D6AFE" />
+              <path
+                d="M33.1713 4.66019C31.117 4.66019 29.5062 5.42913 28.409 6.71068V5.12621H23.2032V20.2718H28.409V13.4913C28.4557 10.5786 29.7397 9.34369 31.8407 9.34369C33.6382 9.34369 34.3385 10.2524 34.3385 12.4194V20.2718H39.5444V11.5107C39.5444 6.92039 37.8169 4.66019 33.1713 4.66019Z"
+                fill="#6D6AFE" />
+              <path
+                d="M46.0405 10.0893V0H40.8347V20.2718H46.0405V16.7068L48.2116 14.167L50.7328 20.2718H56.4755L53.184 12.233H49.869L56.0087 5.12621H50.3359L46.0405 10.0893Z"
+                fill="#6D6AFE" />
+              <path
+                d="M67.0849 20.7379C70.2364 20.7379 74.1116 18.9437 74.1116 12.699C74.1116 6.45437 70.2364 4.66019 67.0849 4.66019C65.3341 4.66019 63.77 5.17281 62.5094 6.03495V0H57.3035V20.2718H62.5094V19.3631C63.77 20.2485 65.3341 20.7379 67.0849 20.7379ZM65.7076 16.1942C63.91 16.1942 62.5094 15.2854 62.5094 12.699V12.5126C62.5794 10.0893 63.9567 9.20388 65.7076 9.20388C67.7152 9.20388 68.9058 10.2524 68.9058 12.699C68.9058 15.1689 67.7152 16.1942 65.7076 16.1942Z"
+                fill="#6D6AFE" />
+              <path
+                d="M74.935 20.2718H80.1409V13.9573C80.1876 11.0214 81.5182 9.32039 86.1638 9.32039V4.66019C83.3624 4.66019 81.3781 5.63883 80.1409 7.1068V5.12621H74.935V20.2718Z"
+                fill="#6D6AFE" />
+              <path
+                d="M93.541 20.7379C95.2685 20.7379 96.8559 20.2485 98.1165 19.3631V20.2718H103.322V5.12621H98.1165V6.03495C96.8559 5.17281 95.2685 4.66019 93.541 4.66019C90.3895 4.66019 86.5143 6.45437 86.5143 12.699C86.5143 18.9437 90.3895 20.7379 93.541 20.7379ZM94.9183 16.1942C92.9107 16.1942 91.7201 15.1689 91.7201 12.699C91.7201 10.2524 92.9107 9.20388 94.9183 9.20388C96.7159 9.20388 98.1165 10.1359 98.1165 12.699C98.1165 15.2854 96.7159 16.1942 94.9183 16.1942Z"
+                fill="#6D6AFE" />
+              <path
+                d="M104.613 20.2718H109.819V13.9573C109.865 11.0214 111.196 9.32039 115.841 9.32039V4.66019C113.04 4.66019 111.056 5.63883 109.819 7.1068V5.12621H104.613V20.2718Z"
+                fill="#6D6AFE" />
+              <path
+                d="M127.794 5.12621V11.7204C127.234 12.3495 126.23 12.6058 125.063 12.6058C122.588 12.6058 121.865 11.8369 121.865 10.4155V5.12621H116.659V10.7883C116.659 14.9359 119.6 17.1728 123.686 17.1728C125.203 17.1728 126.604 16.8466 127.794 16.2874V16.8466C127.794 18.9204 127 19.666 124.946 19.666C123.242 19.666 122.425 19.1534 122.191 17.965H116.962C117.383 22.2524 119.694 24 124.946 24C130.666 24 133 21.9029 133 16.4505V5.12621H127.794Z"
+                fill="#6D6AFE" />
+            </svg>
+          </a>
 
-        <div class="signup__logoSection--text">
-          <p>
-            이미 회원이신가요? <a href="./loginin.html">로그인하기</a>
-          </p>
-        </div>
-      </div>
-
-
-      <form class="sign__form">
-        <div class="signup__form--inputbox">
-          <label for="signup__email-form">이메일</label>
-          <input id="signup__email-form" name="email" type="email">
-        </div>
-        <div class="signup__form--inputbox">
-          <label for="signup__password-form">비밀번호</label>
-          <div class="signup__password-container">
-            <input id="signup__password-form" name="password" type="password">
-            <i class="fa-solid fa-eye"></i>
-            <p class=".signup__password-form--error"></p>
+          <div class="signup__logoSection--text">
+            <p>
+              이미 회원이신가요? <a href="./loginin.html">로그인하기</a>
+            </p>
           </div>
         </div>
-        <div class="signup__form--inputbox">
-          <label for="signup__pwscheck-form">비밀번호 확인</label>
-          <div class="signup__password-container">
-            <input id="signup__pwscheck-form" name="pwcheck" type="password">
-            <i class="fa-solid fa-eye"></i>
+
+
+        <form class="sign__form">
+          <div class="signup__inputsection">
+            <div class="signup__form--inputbox">
+              <label for="signup__email-form">이메일</label>
+              <input id="signup__email-form" name="email" type="email">
+              <p class="signup__email-form--error"></p>
+            </div>
+            <div class="signup__form--inputbox">
+              <label for="signup__password-form">비밀번호</label>
+              <div class="signup__password-container">
+                <input id="signup__password-form" name="password" type="password">
+                <i class="password__toggle-icon fa-solid fa-eye"></i>
+                <p class="signup__password-form--error"></p>
+              </div>
+            </div>
+            <div class="signup__form--inputbox">
+              <label for="signup__pwscheck-form">비밀번호 확인</label>
+              <div class="signup__password-container">
+                <input id="signup__pwscheck-form" name="pwcheck" type="password">
+                <i class="pwcheck__toggle-icon fa-solid fa-eye"></i>
+                <p class="signup__pwcheck-form--error"></p>
+              </div>
+            </div>
           </div>
+          <button type="button" class="signup__form--signupBt" href="#">회원가입</button>
+        </form>
+      </article>
+      <article class="signup-another">
+        <p>
+          <span>다른 방식으로 가입하기</span>
+        </p>
+        <div class="link">
+          <a class="signup-another__google" href="#">
+            <img src="./img/google.png">
+          </a>
+          <a class="signup-another__kakao" href="#">
+            <img src="./img/kakaotalk.png">
+          </a>
         </div>
-      </form>
-      <form class="sign__button-form">
-        <button class="signup__form--signupBt" href="#">회원가입</button>
-      </form>
-    </article>
-    <article class="signup-another">
-      <p>
-        <span>다른 방식으로 가입하기</span>
-      </p>
-      <div class="link">
-        <a class="signup-another__google" href="#">
-          <img src="./img/google.png">
-        </a>
-        <a class="signup-another__kakao" href="#">
-          <img src="./img/kakaotalk.png">
-        </a>
-      </div>
-    </article>
-  </section>
+      </article>
+    </section>
+  </main>
+
+  <script type="module" src="signup.js"></script>
 </body>
 
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,103 @@
+import * as input from './commonChange_input.js';
+
+const signupEmailInput = document.querySelector('#signup__email-form');
+const signupPwInput = document.querySelector('#signup__password-form');
+const signupPwCheckInput = document.querySelector('#signup__pwscheck-form');
+
+const signupEmailError = document.querySelector('.signup__email-form--error');
+const signupPwError = document.querySelector('.signup__password-form--error');
+const signupPwCheckError = document.querySelector('.signup__pwcheck-form--error');
+
+const signupButton = document.querySelector('.signup__form--signupBt');
+const signupPasswordIcon = document.querySelector('.password__toggle-icon');
+const signupPwcheckIcon = document.querySelector('.pwcheck__toggle-icon');
+
+signupEmailInput.addEventListener('focusout', signupEmailFocusOut);
+signupPwInput.addEventListener('focusout', signuppwFocusOut);
+signupPwCheckInput.addEventListener('focusout', signupPwCheckFocusOut);
+
+signupPasswordIcon.addEventListener('click', passwordToggleIcon);
+signupPwcheckIcon.addEventListener('click', pwcheckToggleIcon)
+signupButton.addEventListener('click', handlesignupButtonClick);
+
+signupEmailInput.addEventListener('keyup', handlesignupButtonEnter);
+signupPwInput.addEventListener('keyup', handlesignupButtonEnter);
+signupPwCheckInput.addEventListener('keyup', handlesignupButtonEnter);
+
+
+//이메일 입력 확인 (공통)
+function signupEmailFocusOut(event) {
+  input.emailHandleInputFocusOut(signupEmailInput, signupEmailError);
+}
+
+//비밀번호 확인 (공통)
+function signuppwFocusOut(event) {
+  input.passwordHandleFocusOut(signupPwInput, signupPwError);
+}
+
+//입력한 비밀번호 재확인 
+function signupPwCheckFocusOut(event) {
+  pwCheckHandleFocusOut(signupPwCheckInput, signupPwInput, signupPwCheckError);
+}
+
+function pwCheckHandleFocusOut(inputElement, inputcompareElement, errorElement) {
+  if (inputcompareElement.value != inputElement.value) {
+    errorElement.textContent = '비밀번호가 일치하지 않습니다.';
+    errorElement.style.display = 'block';
+    inputElement.style.borderColor = '#FF5B56';
+  } else {
+    input.noError(inputElement, errorElement);
+  }
+}
+
+//비밀번호 아이콘 및 타입 변경 (공통)
+function passwordToggleIcon(event) {
+  input.togglePasswordType(signupPwInput, signupPasswordIcon);
+}
+
+function pwcheckToggleIcon(event) {
+  input.togglePasswordType(signupPwCheckInput, signupPwcheckIcon);
+}
+
+//엔터키
+function handlesignupButtonEnter(event) {
+  if (event.code === 'Enter') {
+    handlesignupButtonClick();
+  }
+}
+
+//로그인 버튼 클릭 시
+function handlesignupButtonClick(event) {
+  if(signupEmailInput.value !== '' && signupEmailInput.value !== '' && signupEmailInput.value !== '' ){
+    if (signupEmailInput.value !== 'test@codeit.com') {
+      if (signupPwInput.value === signupPwCheckInput.value) {
+        window.location.href = "/folder";
+      }
+      else {
+        //비밀번호 일치하지않음
+        pwCheckHandleFocusOut(signupPwCheckInput, signupPwInput, signupPwCheckError);
+      }
+    }
+    else {
+      emailExistence();
+    }
+  } else {
+    blinkInput();
+  }
+}
+
+//이메일이 이미 저장되어있는 정보와 같을 때 (arraw function)
+const emailExistence = () => {
+  signupEmailError.textContent = '이미 사용중인 이메일 입니다.';
+  signupEmailError.style.display = 'block';
+  signupEmailInput.style.borderColor = '#FF5B56';
+}
+
+const blinkInput = () => {
+  signupPwError.textContent = '비밀번호를 확인해 주세요.';
+  signupPwError.style.display = 'block';
+  signupPwInput.style.borderColor = '#FF5B56'; 
+  signupEmailError.textContent = '이메일을 확인해 주세요.';
+  signupEmailError.style.display = 'block';
+  signupEmailInput.style.borderColor = '#FF5B56'; 
+}


### PR DESCRIPTION
## 요구사항

### 기본
- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화
- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- signup 페이지의 input focusout 시 발생하는 이벤트(이메일 오류, 미입력, 이미 존재하는 이메일, 비밀번호 불일치 등) 등록
- 비밀번호 보이기 아이콘 등록
- 유효한 회원가입 시 /folder 이동

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
