### PR TITLE
[홍성욱] week5

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,3 +1,6 @@
+const USER_EMAIL = "test@codeit.com";
+const USER_PASSWORD = "codeit101";
+
 // email input
 const inputEmail = document.querySelector(".sign-input");
 const inputBoxEmail = document.querySelector(".sign-input-box");
@@ -11,99 +14,73 @@ const eyeButton = document.querySelector(".eye-button");
 const eyeImg = document.querySelector("#eye-id");
 
 function isValidEmail(emailAdress) {
-    let exptext = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+    const exptext = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
     return exptext.test(emailAdress);
+}
+
+function showErrorMessage(element, message) {
+    const inputChild = element === inputBoxEmail ? element.children[1] : element.children[2];
+    console.log(inputChild);
+    const lastChild = element.lastElementChild;
+
+    if(lastChild === inputChild) {
+        const newErrorTag = document.createElement("p");
+        newErrorTag.textContent = message;
+        
+        element.append(newErrorTag);
+        inputChild.classList.add('error-border');
+        newErrorTag.classList.add('error-text');
+    } else {
+        lastChild.textContent = message;
+    }
+}
+function removeMessage(element) {
+    const inputChild = element === inputBoxEmail ? element.children[1] : element.children[2];
+    const lastChild = element.lastElementChild;
+    if(lastChild !== inputChild) {
+        lastChild.remove();
+        inputChild.classList.remove('error-border');
+    }
 }
 // focus-out email
 function eventFocusOutEmail() {
     // no email value
     if(inputEmail.value === "") {
-        if(inputBoxEmail.lastElementChild === inputEmail) {
-            const nothingInput = document.createElement("p");
-            nothingInput.textContent = "이메일을 입력해주세요";
-            inputBoxEmail.append(nothingInput);
-
-            inputEmail.classList.add('error-border');
-            nothingInput.classList.add('error-text');
-        } else {
-            inputBoxEmail.lastElementChild.textContent = "이메일을 입력해주세요";
-        }
+        showErrorMessage(inputBoxEmail, "이메일을 입력해주세요");
     }
     // not email form
     else if(!isValidEmail(inputEmail.value)) {
-        if(inputBoxEmail.lastElementChild === inputEmail) {
-            const invalidInput = document.createElement("p");
-            invalidInput.textContent = "올바른 이메일 주소가 아닙니다.";
-            inputBoxEmail.append(invalidInput);
-
-            inputEmail.classList.add('error-border');
-            invalidInput.classList.add('error-text');
-        } else {
-            inputBoxEmail.lastElementChild.textContent = "올바른 이메일 주소가 아닙니다.";
-        }
+        showErrorMessage(inputBoxEmail, "올바른 이메일 주소가 아닙니다.");
     }
     // error message remove
     else if(isValidEmail(inputEmail.value)) {
-        if(inputBoxEmail.lastElementChild !== inputEmail) {
-            inputBoxEmail.lastElementChild.remove();
-            inputEmail.classList.remove('error-border');
-        }
+        removeMessage(inputBoxEmail);
     }
 }
 // focus-out password
 function eventFocusOutPassword() {
     // no password value
     if(inputPassword.value === "") {
-        if(inputBoxPassword.lastElementChild === inputPassword) {
-            const nothingInput = document.createElement("p");
-            nothingInput.textContent = "비밀번호를 입력해주세요.";
-            inputBoxPassword.append(nothingInput);
-
-            inputPassword.classList.add('error-border');
-            nothingInput.classList.add('error-text');
-        } else {
-            inputBoxPassword.lastElementChild.textContent = "비밀번호를 입력해주세요.";
-        }
+        showErrorMessage(inputBoxPassword, "비밀번호를 입력해주세요")
     }
     else {
-        if(inputBoxPassword.lastElementChild !== inputPassword) {
-            inputBoxPassword.lastElementChild.remove();
-            inputPassword.classList.remove('error-border');
-        }
+        removeMessage(inputBoxPassword);
     }
 }
 // login button click
 function eventClickBtn() {
-    if(inputEmail.value === "test@codeit.com" && inputPassword.value === "codeit101") {
+    if(inputEmail.value === USER_EMAIL && inputPassword.value === USER_PASSWORD) {
         window.location.href = "/folder"
     }
-    if(inputEmail.value !== "test@codeit.com") {
-        if(inputBoxEmail.lastElementChild === inputEmail) {
-            const invalidInput = document.createElement("p");
-            invalidInput.textContent = "아이디를 확인해주세요.";
-            inputBoxEmail.append(invalidInput);
-
-            inputEmail.classList.add('error-border');
-            invalidInput.classList.add('error-text');
-        } else {
-            inputBoxEmail.lastElementChild.textContent = "아이디를 확인해주세요.";
-        }
+    if(inputEmail.value !== USER_EMAIL) {
+        showErrorMessage(inputBoxEmail, "아이디를 확인해주세요.");
     }
-    if(inputPassword.value !== "codeit101") {
-        if(inputBoxPassword.lastElementChild === inputPassword) {
-            const nothingInput = document.createElement("p");
-            nothingInput.textContent = "비밀번호를 확인해주세요.";
-            inputBoxPassword.append(nothingInput);
-
-            inputPassword.classList.add('error-border');
-            nothingInput.classList.add('error-text');
-        } else {
-            inputBoxPassword.lastElementChild.textContent = "비밀번호를 확인해주세요.";
-        }
+    if(inputPassword.value !== USER_PASSWORD) {
+        showErrorMessage(inputBoxPassword, "비밀번호를 확인해주세요.");
     }
 }
 // press Enter
-function eventPressEnter(e) {
+function eventKeyUpEnter(e) {
     if(e.keyCode == 13) {
         eventClickBtn();
     }
@@ -123,5 +100,5 @@ function eventClickEye() {
 inputEmail.addEventListener('focusout', eventFocusOutEmail);
 inputPassword.addEventListener('focusout', eventFocusOutPassword);
 loginButton.addEventListener('click', eventClickBtn);
-document.addEventListener('keyup', eventPressEnter);
+document.addEventListener('keyup', eventKeyUpEnter);
 eyeButton.addEventListener('click', eventClickEye);

--- a/javascript/signin.js
+++ b/javascript/signin.js
@@ -20,7 +20,6 @@ function isValidEmail(emailAdress) {
 
 function showErrorMessage(element, message) {
     const inputChild = element === inputBoxEmail ? element.children[1] : element.children[2];
-    console.log(inputChild);
     const lastChild = element.lastElementChild;
 
     if(lastChild === inputChild) {
@@ -86,15 +85,18 @@ function eventKeyUpEnter(e) {
     }
 }
 
+function clickEyeIcon(element, image) {
+    if(element.type === "password") {
+        element.type = "text";
+        image.src = "./images/eye-on.png";
+    } else {
+        element.type = "password";
+        image.src = "./images/eye-off.png";
+    }
+}
 // press eye-icon
 function eventClickEye() {
-    if(inputPassword.type === "password") {
-        inputPassword.type = "text";
-        eyeImg.src = "./images/eye-on.png";
-    } else {
-        inputPassword.type = "password";
-        eyeImg.src = "./images/eye-off.png";
-    }
+    clickEyeIcon(inputPassword, eyeImg);
 }
 
 inputEmail.addEventListener('focusout', eventFocusOutEmail);
@@ -102,3 +104,7 @@ inputPassword.addEventListener('focusout', eventFocusOutPassword);
 loginButton.addEventListener('click', eventClickBtn);
 document.addEventListener('keyup', eventKeyUpEnter);
 eyeButton.addEventListener('click', eventClickEye);
+
+export {USER_EMAIL, USER_PASSWORD, inputEmail, inputBoxEmail, 
+        inputPassword, inputBoxPassword, loginButton, eyeButton, eyeImg,
+        isValidEmail, showErrorMessage, removeMessage, clickEyeIcon, eventClickEye}

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -1,0 +1,82 @@
+import * as sign from './signin.js';
+
+// password-check input
+const inputPasswordCheck = document.querySelector(".sign-input#password-check");
+const inputBoxPasswordCheck = document.querySelector(".sign-input-box.sign-password-check"); 
+// eye button & img (비밀번호 확인)
+const eyeButtonCheck = document.querySelector(".eye-button-check");
+const eyeImgCheck = document.querySelector("#eye-id-check");
+
+function isValidPassword(passwordValue) {
+    const expPassword = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+    return expPassword.test(passwordValue);    
+}
+// focus-out email
+function eventFocusOutEmail() {
+    // no email value
+    if(sign.inputEmail.value === "") {
+        sign.showErrorMessage(sign.inputBoxEmail, "이메일을 입력해주세요");
+    }
+    // not email form
+    else if(!sign.isValidEmail(sign.inputEmail.value)) {
+        sign.showErrorMessage(sign.inputBoxEmail, "올바른 이메일 주소가 아닙니다.");
+    }
+    else if(sign.inputEmail.value === sign.USER_EMAIL) {
+        sign.showErrorMessage(sign.inputBoxEmail, "이미 사용 중인 이메일입니다.");
+    }
+    // error message remove
+    else if(sign.isValidEmail(sign.inputEmail.value)) {
+        sign.removeMessage(sign.inputBoxEmail);
+    }
+}
+// focus-out password
+function eventFocusOutPassword() {
+    // no password value
+    if(sign.inputPassword.value === "") {
+        sign.showErrorMessage(sign.inputBoxPassword, "비밀번호를 입력해주세요");
+    }
+    else if(!isValidPassword(sign.inputPassword.value)) {
+        sign.showErrorMessage(sign.inputBoxPassword, "비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.");
+    }
+    else {
+        sign.removeMessage(sign.inputBoxPassword);
+    }
+}
+function eventFocusOutPasswordCheck() {
+    // no password value
+    if(inputPasswordCheck.value !== sign.inputPassword.value) {
+        sign.showErrorMessage(inputBoxPasswordCheck, "비밀번호가 일치하지 않아요.");
+    }
+    else {
+        sign.removeMessage(inputBoxPasswordCheck);
+    }
+}
+// signup button click
+function eventClickBtnSignup() {
+    if( sign.isValidEmail(sign.inputEmail.value)
+        && isValidPassword(sign.inputPassword.value)
+        && inputPasswordCheck.value === sign.inputPassword.value ) {
+            window.location.href = "/folder";
+        }
+    else {
+        eventFocusOutEmail();
+        eventFocusOutPassword();
+        eventFocusOutPasswordCheck();
+    }
+}
+function eventKeyUpEnterSignup(e) {
+    if(e.keyCode == 13) {
+        eventClickBtnSignup();
+    }
+}
+function eventClickEyeCheck() {
+    sign.clickEyeIcon(inputPasswordCheck, eyeImgCheck);
+}
+
+sign.inputEmail.addEventListener('focusout', eventFocusOutEmail);
+sign.inputPassword.addEventListener('focusout', eventFocusOutPassword);
+inputPasswordCheck.addEventListener('focusout', eventFocusOutPasswordCheck);
+sign.loginButton.addEventListener('click', eventClickBtnSignup);
+document.addEventListener('keyup', eventKeyUpEnterSignup);
+sign.eyeButton.addEventListener('click', sign.eventClickEye);
+eyeButtonCheck.addEventListener('click', eventClickEyeCheck);

--- a/signin.html
+++ b/signin.html
@@ -24,7 +24,7 @@
             </div>
             <div class="sign-input-box sign-password">
               <button class="eye-button" type="button">
-                <img id="eye-id" src="./images/eye-off.png" />
+                <img id="eye-id" src="./images/eye-off.png" alt="비밀번호 마킹 토글" />
               </button>
               <label for="password" class="sign-input-label">비밀번호</label>
               <input id="password" class="sign-input" type="password" placeholder="내용 입력" />

--- a/signin.html
+++ b/signin.html
@@ -44,6 +44,6 @@
           </div>
         </div>
       </div>
-    <script src="./javascript/index.js"></script>
+    <script type="module" src="./javascript/signin.js"></script>
 </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -20,24 +20,24 @@
           <div class="sign-inputs">
             <div class="sign-input-box">
               <label class="sign-input-label">이메일</label>
-              <input class="sign-input" />
+              <input class="sign-input" type="email" placeholder="내용 입력" />
             </div>
             <div class="sign-input-box sign-password">
-              <label class="sign-input-label">비밀번호</label>
-              <input class="sign-input" type="password" />
               <button class="eye-button" type="button">
-                <img src="./images/eye-off.png" />
+                <img id="eye-id" src="./images/eye-off.png" alt="비밀번호 마킹 토글" />
               </button>
+              <label for="password" class="sign-input-label">비밀번호</label>
+              <input id="password" class="sign-input" type="password" placeholder="내용 입력" />
             </div>
-            <div class="sign-input-box sign-password">
-                <label class="sign-input-label">비밀번호 확인</label>
-                <input class="sign-input" type="password" />
-                <button class="eye-button" type="button">
-                  <img src="./images/eye-off.png" />
-                </button>
+            <div class="sign-input-box sign-password-check">
+              <button class="eye-button-check" type="button">
+                <img id="eye-id-check" src="./images/eye-off.png" alt="비밀번호 마킹 토글" />
+              </button>
+              <label for="password-check" class="sign-input-label">비밀번호 확인</label>
+              <input id="password-check" class="sign-input" type="password" placeholder="내용 입력" />
             </div>
           </div>
-          <button class="cta" type="submit">회원가입</button>
+          <button class="cta" type="button">회원가입</button>
         </form>
         <div class="sns-box">
           <span class="sns-text">다른 방식으로 가입하기</span>
@@ -51,5 +51,6 @@
           </div>
         </div>
       </div>
+      <script type="module" src="./javascript/signup.js"></script>
 </body>
 </html>

--- a/src/sign.css
+++ b/src/sign.css
@@ -69,7 +69,7 @@ header {
     flex-direction: column;
     row-gap: 1.2rem;
 }
-.sign-password {
+.sign-password, .sign-password-check {
     position: relative;
 }
 .sign-input-label {
@@ -88,7 +88,7 @@ header {
 .sign-input:focus {
     border-color: var(--primary);
 }
-.eye-button {
+.eye-button, .eye-button-check {
     position: absolute;
     top: 5.2rem;
     right: 1.5rem;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- week4 피드백 반영: 반복 로직 함수로 구현
- week5 미션 추가

## 스크린샷

https://weekly-mission-hsw.netlify.app/
스크린샷 대신 링크 첨부합니다!

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
