### PR TITLE
[강영훈] week5

### DIFF
--- a/css/sign.css
+++ b/css/sign.css
@@ -98,7 +98,8 @@ input:focus {
 /* 에러 발생 시 변동 사항 */
 
 #errorEmail,
-#errorPassword {
+#errorPassword,
+#errorPasswordCheck {
     display: none;
     color: var(--red);
     font-size: 1.4rem;
@@ -107,7 +108,8 @@ input:focus {
 }
 
 #errorEmail.errorShown,
-#errorPassword.errorShown {
+#errorPassword.errorShown,
+#errorPasswordCheck.errorShown {
     display: block;
 }
 

--- a/css/sign.css
+++ b/css/sign.css
@@ -97,9 +97,7 @@ input:focus {
 
 /* 에러 발생 시 변동 사항 */
 
-#errorEmail,
-#errorPassword,
-#errorPasswordCheck {
+.errorText {
     display: none;
     color: var(--red);
     font-size: 1.4rem;
@@ -107,9 +105,7 @@ input:focus {
     width: 100%;
 }
 
-#errorEmail.errorShown,
-#errorPassword.errorShown,
-#errorPasswordCheck.errorShown {
+.errorText.errorShown {
     display: block;
 }
 

--- a/html/signin.html
+++ b/html/signin.html
@@ -25,7 +25,7 @@
             <div class="email">
                 <label for="signin-email">이메일</label>
                 <input id="signin-email" type="email" placeholder="codeit@coeit.com" />
-                <div id="errorEmail"></div>
+                <div id="errorEmail" class="errorText"></div>
             </div>
             <div class="password">
                 <label for="signin-password">비밀번호</label>
@@ -37,7 +37,7 @@
                         alt="눈 아이콘"
                     />
                     <input id="signin-password" type="password" />
-                    <div id="errorPassword"></div>
+                    <div id="errorPassword" class="errorText"></div>
                 </div>
             </div>
             <button type="submit">로그인</button>

--- a/html/signin.html
+++ b/html/signin.html
@@ -48,7 +48,6 @@
                 /></a>
             </div>
         </div>
-        <script type="module" src="../javascript/constants.js"></script>
         <script type="module" src="../javascript/signin.js"></script>
     </body>
 </html>

--- a/html/signin.html
+++ b/html/signin.html
@@ -30,7 +30,12 @@
             <div class="password">
                 <label for="signin-password">비밀번호</label>
                 <div>
-                    <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
+                    <img
+                        id="eyecon-password"
+                        class="eyecon"
+                        src="../image/icon/eye_closed.svg"
+                        alt="눈 아이콘"
+                    />
                     <input id="signin-password" type="password" />
                     <div id="errorPassword"></div>
                 </div>

--- a/html/signup.html
+++ b/html/signup.html
@@ -40,6 +40,7 @@
                 <div>
                     <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
                     <input id="signup-password-repeat" type="password" />
+                    <div id="errorPasswordCheck"></div>
                 </div>
             </div>
             <button type="submit">회원가입</button>

--- a/html/signup.html
+++ b/html/signup.html
@@ -30,7 +30,12 @@
             <div class="password">
                 <label for="signup-password">비밀번호</label>
                 <div>
-                    <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
+                    <img
+                        id="eyecon-password"
+                        class="eyecon"
+                        src="../image/icon/eye_closed.svg"
+                        alt="눈 아이콘"
+                    />
                     <input id="signup-password" type="password" />
                     <div id="errorPassword"></div>
                 </div>
@@ -38,7 +43,12 @@
             <div class="password-check">
                 <label for="signup-password-repeat">비밀번호 확인</label>
                 <div>
-                    <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
+                    <img
+                        id="eyecon-password-repeat"
+                        class="eyecon"
+                        src="../image/icon/eye_closed.svg"
+                        alt="눈 아이콘"
+                    />
                     <input id="signup-password-repeat" type="password" />
                     <div id="errorPasswordCheck"></div>
                 </div>

--- a/html/signup.html
+++ b/html/signup.html
@@ -25,7 +25,7 @@
             <div class="email">
                 <label for="signup-email">이메일</label>
                 <input id="signup-email" type="email" placeholder="codeit@coeit.com" required />
-                <div id="errorEmail"></div>
+                <div id="errorEmail" class="errorText"></div>
             </div>
             <div class="password">
                 <label for="signup-password">비밀번호</label>
@@ -37,7 +37,7 @@
                         alt="눈 아이콘"
                     />
                     <input id="signup-password" type="password" />
-                    <div id="errorPassword"></div>
+                    <div id="errorPassword" class="errorText"></div>
                 </div>
             </div>
             <div class="password-check">
@@ -50,7 +50,7 @@
                         alt="눈 아이콘"
                     />
                     <input id="signup-password-repeat" type="password" />
-                    <div id="errorPasswordCheck"></div>
+                    <div id="errorPasswordCheck" class="errorText"></div>
                 </div>
             </div>
             <button type="submit">회원가입</button>

--- a/html/signup.html
+++ b/html/signup.html
@@ -1,57 +1,59 @@
 <!DOCTYPE html>
 <html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sign up</title>
-    <link rel="stylesheet" href="../css/sign.css" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css"
-    />
-  </head>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Sign up</title>
+        <link rel="stylesheet" href="../css/sign.css" />
+        <link
+            rel="stylesheet"
+            as="style"
+            crossorigin
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/static/pretendard.css"
+        />
+    </head>
 
-  <body>
-    <div class="sign-title">
-      <a href="/index.html"
-        ><img src="../image/logo/Linkbrary.svg" href="landing.html" alt="Linkbrary" /></a
-      ><br />
-      이미 회원이신가요?
-      <a href="signin.html">로그인 하기</a>
-    </div>
-    <form class="sign-box">
-      <div class="email">
-        <label for="signup-email">이메일</label>
-        <input id="signup-email" type="email" placeholder="codeit@coeit.com" required />
-      </div>
-      <div class="password">
-        <label for="signup-password">비밀번호</label>
-        <div>
-          <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
-          <input id="signup-password" type="password" placeholder="••••••••" required />
+    <body>
+        <div class="sign-title">
+            <a href="/index.html"
+                ><img src="../image/logo/Linkbrary.svg" href="landing.html" alt="Linkbrary" /></a
+            ><br />
+            이미 회원이신가요?
+            <a href="signin.html">로그인 하기</a>
         </div>
-      </div>
-      <div class="password-check">
-        <label for="signup-password-repeat">비밀번호 확인</label>
-        <div>
-          <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
-          <input id="signup-password-repeat" type="password" placeholder="••••••••" required />
+        <form id="sign-box" class="sign-box">
+            <div class="email">
+                <label for="signup-email">이메일</label>
+                <input id="signup-email" type="email" placeholder="codeit@coeit.com" required />
+                <div id="errorEmail"></div>
+            </div>
+            <div class="password">
+                <label for="signup-password">비밀번호</label>
+                <div>
+                    <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
+                    <input id="signup-password" type="password" />
+                </div>
+            </div>
+            <div class="password-check">
+                <label for="signup-password-repeat">비밀번호 확인</label>
+                <div>
+                    <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
+                    <input id="signup-password-repeat" type="password" />
+                </div>
+            </div>
+            <button type="submit">회원가입</button>
+        </form>
+        <div class="social-sign">
+            <div class="social-text">다른 방식으로 가입하기</div>
+            <div class="logo">
+                <a href="https://www.google.com/"
+                    ><img src="../image/logo/google.svg" alt="구글로 가입"
+                /></a>
+                <a href="https://www.kakaocorp.com/page/"
+                    ><img src="../image/logo/kakao.svg" alt="카카오로 가입"
+                /></a>
+            </div>
         </div>
-      </div>
-      <button type="submit">회원가입</button>
-    </form>
-    <div class="social-sign">
-      <div class="social-text">다른 방식으로 가입하기</div>
-      <div class="logo">
-        <a href="https://www.google.com/"
-          ><img src="../image/logo/google.svg" alt="구글로 가입"
-        /></a>
-        <a href="https://www.kakaocorp.com/page/"
-          ><img src="../image/logo/kakao.svg" alt="카카오로 가입"
-        /></a>
-      </div>
-    </div>
-  </body>
+        <script type="module" src="../javascript/signup.js"></script>
+    </body>
 </html>

--- a/html/signup.html
+++ b/html/signup.html
@@ -32,6 +32,7 @@
                 <div>
                     <img class="eyecon" src="../image/icon/eye_closed.svg" alt="눈 아이콘" />
                     <input id="signup-password" type="password" />
+                    <div id="errorPassword"></div>
                 </div>
             </div>
             <div class="password-check">

--- a/javascript/constants.js
+++ b/javascript/constants.js
@@ -3,4 +3,9 @@
  */
 const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-export { emailRegex }
+/**
+ * 비밀번호 정규 상수
+ */
+const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+
+export { emailRegex, passwordRegex }

--- a/javascript/constants.js
+++ b/javascript/constants.js
@@ -1,11 +1,11 @@
 /**
  * 이메일 정규 상수
  */
-const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 /**
  * 비밀번호 정규 상수
  */
-const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{8,}/
 
-export { emailRegex, passwordRegex }
+export { EMAIL_REGEX, PASSWORD_REGEX }

--- a/javascript/constants.js
+++ b/javascript/constants.js
@@ -8,4 +8,18 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
  */
 const PASSWORD_REGEX = /(?=.*\d)(?=.*[a-z]).{8,}/
 
-export { EMAIL_REGEX, PASSWORD_REGEX }
+
+const errorMsg = {
+    emptyEmail: '이메일을 입력해 주세요.',
+    emptyPassword:'비밀번호를 입력해 주세요.',
+    invalidEmail:'올바른 이메일 주소가 아닙니다.',
+    invalidPassword: '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.',
+    checkEmail: '이메일을 확인해 주세요.',
+    checkPassword: '비밀번호를 확인해 주세요.',
+    usedEmail: '이미 사용 중인 이메일입니다.',
+    differentPassword: '비밀번호가 일치하지 않아요.'
+}
+
+const minPasswordLength = 8
+
+export { EMAIL_REGEX, PASSWORD_REGEX, errorMsg, minPasswordLength }

--- a/javascript/sign-error.js
+++ b/javascript/sign-error.js
@@ -1,4 +1,4 @@
-import { emailRegex } from './constants.js'
+import { EMAIL_REGEX } from './constants.js'
 
 /**
  * 해당 값의 빈 값 여부 확인
@@ -12,7 +12,7 @@ const isInputEmpty = (input) => input === ''
  * @param {*} input 확인할 이메일
  * @returns 불린값
  */
-const isEmailValid = (input) => emailRegex.test(input)
+const isEmailValid = (input) => EMAIL_REGEX.test(input)
 
 /**에러 표시 함수
  * @param {*} inputElement 오류가 발생한 input

--- a/javascript/signin.js
+++ b/javascript/signin.js
@@ -4,10 +4,11 @@ const passwordInput = document.querySelector('#signin-password')
 const errorEmail = document.querySelector('#errorEmail')
 const errorPassword = document.querySelector('#errorPassword')
 const passwordCover = document.querySelector('#eyecon-password')
-let isPasswordCovered = false
+const cover = {isPasswordCovered: false}
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
 import { togglePasswordByEyecon as togglePassword } from './toggle-password.js'
+import { errorMsg } from './constants.js'
 
 //////////////// 함수 정의 ////////////////////
 
@@ -18,12 +19,12 @@ const checkEmail = () => {
     const email = emailInput.value.trim()
     // 이메일 미입력 에러
     if (isInputEmpty(email)) {
-        showError(emailInput, errorEmail, '이메일을 입력해 주세요.')
+        showError(emailInput, errorEmail, errorMsg.emptyEmail)
         return
     }
     // 이메일 형식 확인
     if (!isEmailValid(email)) {
-        showError(emailInput, errorEmail, '올바른 이메일 주소가 아닙니다.')
+        showError(emailInput, errorEmail, errorMsg.invalidEmail)
         return
     }
 }
@@ -35,7 +36,7 @@ const checkEmail = () => {
 const checkPassword = () => {
     const password = passwordInput.value.trim()
     if (isInputEmpty(password)) {
-        showError(passwordInput, errorPassword, '비밀번호를 입력해 주세요.')
+        showError(passwordInput, errorPassword, errorMsg.emptyPassword)
     }
 }
 /**
@@ -61,8 +62,8 @@ const validateEmail = (event) => {
         window.location.href = '../html/folder.html'
         return
     }
-    showError(emailInput, errorEmail, '이메일을 확인해 주세요.')
-    showError(passwordInput, errorPassword, '비밀번호를 확인해 주세요.')
+    showError(emailInput, errorEmail, errorMsg.checkEmail)
+    showError(passwordInput, errorPassword, errorMsg.checkPassword)
     event.preventDefault()
 }
 
@@ -79,8 +80,8 @@ const handlePasswordFocusout = () => {
 }
 
 const handlePasswordClick = () => {
-    togglePassword(passwordInput, isPasswordCovered, passwordCover)
-    isPasswordCovered = !isPasswordCovered
+    togglePassword(passwordInput, cover.isPasswordCovered, passwordCover)
+    cover.isPasswordCovered = !cover.isPasswordCovered
 }
 
 //////////////// 함수 사용////////////////////

--- a/javascript/signin.js
+++ b/javascript/signin.js
@@ -3,7 +3,7 @@ const emailInput = document.querySelector('#signin-email')
 const passwordInput = document.querySelector('#signin-password')
 const errorEmail = document.querySelector('#errorEmail')
 const errorPassword = document.querySelector('#errorPassword')
-const passwordCover = document.querySelector('.eyecon')
+const passwordCover = document.querySelector('#eyecon-password')
 let isPasswordCovered = false
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'

--- a/javascript/signin.js
+++ b/javascript/signin.js
@@ -9,6 +9,7 @@ const cover = {isPasswordCovered: false}
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
 import { togglePasswordByEyecon as togglePassword } from './toggle-password.js'
 import { errorMsg } from './constants.js'
+import { codeit } from './user-data.js'
 
 //////////////// 함수 정의 ////////////////////
 
@@ -45,7 +46,6 @@ const checkPassword = () => {
  * @returns 불린값
  */
 const isEmailConfirmed = () => {
-    const codeit = { email: 'test@codeit.com', password: 'codeit101' }
     const email = emailInput.value.trim()
     const password = passwordInput.value.trim()
     return email === codeit.email && password === codeit.password

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -1,3 +1,4 @@
+const form = document.querySelector('#sign-box')
 const emailInput = document.querySelector('#signup-email')
 const errorEmail = document.querySelector('#errorEmail')
 const passwordInput = document.querySelector('#signup-password')
@@ -20,19 +21,7 @@ const isEmailUsed = (input) => {
     return input === codeit.email
 }
 
-/**
- * 비밀번호 유효성 확인
- * 8자 이상이며 문자와 숫자의 혼용 여부 확인
- * @param {*} input 확인할 비밀번호
- * @returns 위 사항을 동시에 만족하는지에 대한 불린값
- */
-const isPasswordValid = (input) => {
-    const minPasswordLength = 8
-    return PASSWORD_REGEX.test(input) && input.length >= minPasswordLength
-}
-
-/**이메일 확인 함수
- * 이메일 확인 후 error 메세지 출력
+/**이메일 확인 후 error 메세지 출력
  */
 const checkEmail = () => {
     const email = emailInput.value.trim()
@@ -52,9 +41,25 @@ const checkEmail = () => {
     }
 }
 
-/**
- * 비번 확인 함수
- * 빈 input 시 error 메세지 출력
+/**이메일 사용 가능 여부를 불린으로 반환
+ * @returns 이메일 사용 가능 여부
+ */
+const IsEmailUsable = () => {
+    const email = emailInput.value.trim()
+    return !isInputEmpty(email) && isEmailValid(email) && !isEmailUsed(email)
+}
+
+/** 비밀번호 유효성 확인
+ * 8자 이상이며 문자와 숫자의 혼용 여부 확인
+ * @param {*} input 확인할 비밀번호
+ * @returns 위 사항을 동시에 만족하는지에 대한 불린값
+ */
+const isPasswordValid = (input) => {
+    const minPasswordLength = 8
+    return PASSWORD_REGEX.test(input) && input.length >= minPasswordLength
+}
+
+/**비밀번호 확인 함수
  */
 const checkPassword = () => {
     const password = passwordInput.value.trim()
@@ -66,13 +71,36 @@ const checkPassword = () => {
         )
     }
 }
-
+/**비밀번호 재확인 함수
+ */
 const checkPasswordConfirm = () => {
     const passwordCheck = passwordCheckInput.value.trim()
     const password = passwordInput.value.trim()
     if (passwordCheck !== password) {
         showError(passwordCheckInput, errorPasswordCheck, '비밀번호가 일치하지 않아요.')
     }
+}
+
+//todo//
+//비밀번호 input 상수 꺼내기
+const IsPasswordUsable = () => {
+    const passwordCheck = passwordCheckInput.value.trim()
+    const password = passwordInput.value.trim()
+    return isPasswordValid(password) && passwordCheck === password
+}
+
+//todo//
+//계정 유효성 확인하기
+const validateAccount = (event) => {
+    if (IsEmailUsable() && IsPasswordUsable()) {
+        event.preventDefault()
+        window.location.href = '../html/folder.html'
+        return
+    }
+    event.preventDefault()
+    checkEmail()
+    checkPassword()
+    checkPasswordConfirm()
 }
 
 /////////핸들러 함수///////
@@ -98,3 +126,5 @@ emailInput.addEventListener('focusout', handleEmailFocusout)
 passwordInput.addEventListener('focusout', handlePasswordFocusout)
 // 비번 확인 이벤트 리스너 부여
 passwordCheckInput.addEventListener('focusout', handlePasswordCheckFocusout)
+// 로그인 버튼 입력 시 이메일 비번 확인 후 이동
+form.addEventListener('submit', validateAccount)

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -7,12 +7,15 @@ const passwordCheckInput = document.querySelector('#signup-password-repeat')
 const errorPasswordCheck = document.querySelector('#errorPasswordCheck')
 const passwordCover = document.querySelector('#eyecon-password')
 const passwordCheckCover = document.querySelector('#eyecon-password-repeat')
-let isPasswordCovered = false
-let isPasswordCheckCovered = false
+const cover = {
+    isPasswordCovered: false,
+    isPasswordCheckCovered: false
+}
+
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
 import { togglePasswordByEyecon as togglePassword } from './toggle-password.js'
-import { PASSWORD_REGEX } from './constants.js'
+import { PASSWORD_REGEX, errorMsg, minPasswordLength } from './constants.js'
 
 /////////////////////////////////////
 
@@ -32,17 +35,17 @@ const checkEmail = () => {
     const email = emailInput.value.trim()
     // 이메일 미입력 에러
     if (isInputEmpty(email)) {
-        showError(emailInput, errorEmail, '이메일을 입력해 주세요.')
+        showError(emailInput, errorEmail, errorMsg.emptyEmail)
         return
     }
     // 이메일 형식 확인
     if (!isEmailValid(email)) {
-        showError(emailInput, errorEmail, '올바른 이메일 주소가 아닙니다.')
+        showError(emailInput, errorEmail, errorMsg.invalidEmail)
         return
     }
     // 이메일 중복 확인
     if (isEmailUsed(email)) {
-        showError(emailInput, errorEmail, '이미 사용 중인 이메일입니다.')
+        showError(emailInput, errorEmail, errorMsg.usedEmail)
     }
 }
 
@@ -60,7 +63,6 @@ const IsEmailUsable = () => {
  * @returns 위 사항을 동시에 만족하는지에 대한 불린값
  */
 const isPasswordValid = (input) => {
-    const minPasswordLength = 8
     return PASSWORD_REGEX.test(input) && input.length >= minPasswordLength
 }
 
@@ -72,7 +74,7 @@ const checkPassword = () => {
         showError(
             passwordInput,
             errorPassword,
-            '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.'
+            errorMsg.invalidPassword
         )
     }
 }
@@ -82,7 +84,7 @@ const checkPasswordConfirm = () => {
     const passwordCheck = passwordCheckInput.value.trim()
     const password = passwordInput.value.trim()
     if (passwordCheck !== password) {
-        showError(passwordCheckInput, errorPasswordCheck, '비밀번호가 일치하지 않아요.')
+        showError(passwordCheckInput, errorPasswordCheck, errorMsg.differentPassword)
     }
 }
 
@@ -93,12 +95,11 @@ const IsPasswordUsable = () => {
 }
 
 const validateAccount = (event) => {
+    event.preventDefault()
     if (IsEmailUsable() && IsPasswordUsable()) {
-        event.preventDefault()
         window.location.href = '../html/folder.html'
         return
     }
-    event.preventDefault()
     checkEmail()
     checkPassword()
     checkPasswordConfirm()
@@ -120,14 +121,13 @@ const handlePasswordCheckFocusout = () => {
 }
 
 const handlePasswordClick = () => {
-    togglePassword(passwordInput, isPasswordCovered, passwordCover)
-    isPasswordCovered = !isPasswordCovered
+    togglePassword(passwordInput, cover.isPasswordCovered, passwordCover)
+    cover.isPasswordCovered = !cover.isPasswordCovered
 }
-///todo///
-// 비밀번호 눈 아이콘이랑 비밀번호 재확인 아이콘 분리
+
 const handlePasswordCheckClick = () => {
-    togglePassword(passwordCheckInput, isPasswordCheckCovered, passwordCheckCover)
-    isPasswordCheckCovered = !isPasswordCheckCovered
+    togglePassword(passwordCheckInput, cover.isPasswordCheckCovered, passwordCheckCover)
+    cover.isPasswordCheckCovered = !cover.isPasswordCheckCovered
 }
 //////////////// 함수 사용////////////////////
 

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -5,8 +5,18 @@ import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.
 
 /////////////////////////////////////
 
+/**
+ * 이메일 중복 확인 함수
+ * @param {*} input 확인할 이메일
+ * @returns 중복 여부 불린값
+ */
+const isEmailUsed = (input) => {
+    const codeit = { email: 'test@codeit.com' }
+    return input === codeit.email
+}
+
 /**이메일 확인 함수
- * 이메일 형식과 빈 input 확인 후 error 메세지 출력
+ * 이메일 확인 후 error 메세지 출력
  */
 const checkEmail = () => {
     const email = emailInput.value.trim()
@@ -18,6 +28,11 @@ const checkEmail = () => {
     // 이메일 형식 확인
     if (!isEmailValid(email)) {
         showError(emailInput, errorEmail, '올바른 이메일 주소가 아닙니다.')
+        return
+    }
+    // 이메일 중복 확인
+    if (isEmailUsed(email)) {
+        showError(emailInput, errorEmail, '이미 사용 중인 이메일입니다.')
     }
 }
 

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -5,8 +5,13 @@ const passwordInput = document.querySelector('#signup-password')
 const errorPassword = document.querySelector('#errorPassword')
 const passwordCheckInput = document.querySelector('#signup-password-repeat')
 const errorPasswordCheck = document.querySelector('#errorPasswordCheck')
+const passwordCover = document.querySelector('#eyecon-password')
+const passwordCheckCover = document.querySelector('#eyecon-password-repeat')
+let isPasswordCovered = false
+let isPasswordCheckCovered = false
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
+import { togglePasswordByEyecon as togglePassword } from './toggle-password.js'
 import { PASSWORD_REGEX } from './constants.js'
 
 /////////////////////////////////////
@@ -81,16 +86,12 @@ const checkPasswordConfirm = () => {
     }
 }
 
-//todo//
-//비밀번호 input 상수 꺼내기
 const IsPasswordUsable = () => {
     const passwordCheck = passwordCheckInput.value.trim()
     const password = passwordInput.value.trim()
     return isPasswordValid(password) && passwordCheck === password
 }
 
-//todo//
-//계정 유효성 확인하기
 const validateAccount = (event) => {
     if (IsEmailUsable() && IsPasswordUsable()) {
         event.preventDefault()
@@ -118,6 +119,16 @@ const handlePasswordCheckFocusout = () => {
     checkPasswordConfirm()
 }
 
+const handlePasswordClick = () => {
+    togglePassword(passwordInput, isPasswordCovered, passwordCover)
+    isPasswordCovered = !isPasswordCovered
+}
+///todo///
+// 비밀번호 눈 아이콘이랑 비밀번호 재확인 아이콘 분리
+const handlePasswordCheckClick = () => {
+    togglePassword(passwordCheckInput, isPasswordCheckCovered, passwordCheckCover)
+    isPasswordCheckCovered = !isPasswordCheckCovered
+}
 //////////////// 함수 사용////////////////////
 
 // 이메일 이벤트 리스너 부여
@@ -128,3 +139,7 @@ passwordInput.addEventListener('focusout', handlePasswordFocusout)
 passwordCheckInput.addEventListener('focusout', handlePasswordCheckFocusout)
 // 로그인 버튼 입력 시 이메일 비번 확인 후 이동
 form.addEventListener('submit', validateAccount)
+// 비번 가리기 버튼 리스너 부여
+passwordCover.addEventListener('click', handlePasswordClick)
+// 비번 재확인 가리기 버튼 리스너 부여
+passwordCheckCover.addEventListener('click', handlePasswordCheckClick)

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -16,6 +16,7 @@ const cover = {
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
 import { togglePasswordByEyecon as togglePassword } from './toggle-password.js'
 import { PASSWORD_REGEX, errorMsg, minPasswordLength } from './constants.js'
+import { codeit } from './user-data.js'
 
 /////////////////////////////////////
 
@@ -24,10 +25,7 @@ import { PASSWORD_REGEX, errorMsg, minPasswordLength } from './constants.js'
  * @param {*} input 확인할 이메일
  * @returns 중복 여부 불린값
  */
-const isEmailUsed = (input) => {
-    const codeit = { email: 'test@codeit.com' }
-    return input === codeit.email
-}
+const isEmailUsed = (input) => ( input === codeit.email )
 
 /**이메일 확인 후 error 메세지 출력
  */
@@ -94,7 +92,7 @@ const IsPasswordUsable = () => {
     return isPasswordValid(password) && passwordCheck === password
 }
 
-const validateAccount = (event) => {
+const handleFormSubmit = (event) => {
     event.preventDefault()
     if (IsEmailUsable() && IsPasswordUsable()) {
         window.location.href = '../html/folder.html'
@@ -138,7 +136,7 @@ passwordInput.addEventListener('focusout', handlePasswordFocusout)
 // 비번 확인 이벤트 리스너 부여
 passwordCheckInput.addEventListener('focusout', handlePasswordCheckFocusout)
 // 로그인 버튼 입력 시 이메일 비번 확인 후 이동
-form.addEventListener('submit', validateAccount)
+form.addEventListener('submit', handleFormSubmit)
 // 비번 가리기 버튼 리스너 부여
 passwordCover.addEventListener('click', handlePasswordClick)
 // 비번 재확인 가리기 버튼 리스너 부여

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -1,7 +1,10 @@
 const emailInput = document.querySelector('#signup-email')
 const errorEmail = document.querySelector('#errorEmail')
+const passwordInput = document.querySelector('#signup-password')
+const errorPassword = document.querySelector('#errorPassword')
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
+import { passwordRegex } from './constants.js'
 
 /////////////////////////////////////
 
@@ -13,6 +16,17 @@ import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.
 const isEmailUsed = (input) => {
     const codeit = { email: 'test@codeit.com' }
     return input === codeit.email
+}
+
+/**
+ * 비밀번호 유효성 확인
+ * 8자 이상이며 문자와 숫자의 혼용 여부 확인
+ * @param {*} input 확인할 비밀번호
+ * @returns 위 사항을 동시에 만족하는지에 대한 불린값
+ */
+const isPasswordValid = (input) => {
+    const minPasswordLength = 8
+    return passwordRegex.test(input) && input.length >= minPasswordLength
 }
 
 /**이메일 확인 함수
@@ -36,14 +50,35 @@ const checkEmail = () => {
     }
 }
 
+/**
+ * 비번 확인 함수
+ * 빈 input 시 error 메세지 출력
+ */
+const checkPassword = () => {
+    const password = passwordInput.value.trim()
+    if (!isPasswordValid(password)) {
+        showError(
+            passwordInput,
+            errorPassword,
+            '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.'
+        )
+    }
+}
+
 /////////핸들러 함수///////
 
 const handleEmailFocusout = () => {
     clearError(emailInput, errorEmail)
     checkEmail()
 }
+const handlePasswordFocusout = () => {
+    clearError(passwordInput, errorPassword)
+    checkPassword()
+}
 
 //////////////// 함수 사용////////////////////
 
 // 이메일 이벤트 리스너 부여
 emailInput.addEventListener('focusout', handleEmailFocusout)
+// 비번 이벤트 리스너 부여
+passwordInput.addEventListener('focusout', handlePasswordFocusout)

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -1,0 +1,34 @@
+const emailInput = document.querySelector('#signup-email')
+const errorEmail = document.querySelector('#errorEmail')
+
+import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
+
+/////////////////////////////////////
+
+/**이메일 확인 함수
+ * 이메일 형식과 빈 input 확인 후 error 메세지 출력
+ */
+const checkEmail = () => {
+    const email = emailInput.value.trim()
+    // 이메일 미입력 에러
+    if (isInputEmpty(email)) {
+        showError(emailInput, errorEmail, '이메일을 입력해 주세요.')
+        return
+    }
+    // 이메일 형식 확인
+    if (!isEmailValid(email)) {
+        showError(emailInput, errorEmail, '올바른 이메일 주소가 아닙니다.')
+    }
+}
+
+/////////핸들러 함수///////
+
+const handleEmailFocusout = () => {
+    clearError(emailInput, errorEmail)
+    checkEmail()
+}
+
+//////////////// 함수 사용////////////////////
+
+// 이메일 이벤트 리스너 부여
+emailInput.addEventListener('focusout', handleEmailFocusout)

--- a/javascript/signup.js
+++ b/javascript/signup.js
@@ -2,9 +2,11 @@ const emailInput = document.querySelector('#signup-email')
 const errorEmail = document.querySelector('#errorEmail')
 const passwordInput = document.querySelector('#signup-password')
 const errorPassword = document.querySelector('#errorPassword')
+const passwordCheckInput = document.querySelector('#signup-password-repeat')
+const errorPasswordCheck = document.querySelector('#errorPasswordCheck')
 
 import { isEmailValid, isInputEmpty, showError, clearError } from './sign-error.js'
-import { passwordRegex } from './constants.js'
+import { PASSWORD_REGEX } from './constants.js'
 
 /////////////////////////////////////
 
@@ -26,7 +28,7 @@ const isEmailUsed = (input) => {
  */
 const isPasswordValid = (input) => {
     const minPasswordLength = 8
-    return passwordRegex.test(input) && input.length >= minPasswordLength
+    return PASSWORD_REGEX.test(input) && input.length >= minPasswordLength
 }
 
 /**이메일 확인 함수
@@ -65,6 +67,14 @@ const checkPassword = () => {
     }
 }
 
+const checkPasswordConfirm = () => {
+    const passwordCheck = passwordCheckInput.value.trim()
+    const password = passwordInput.value.trim()
+    if (passwordCheck !== password) {
+        showError(passwordCheckInput, errorPasswordCheck, '비밀번호가 일치하지 않아요.')
+    }
+}
+
 /////////핸들러 함수///////
 
 const handleEmailFocusout = () => {
@@ -75,6 +85,10 @@ const handlePasswordFocusout = () => {
     clearError(passwordInput, errorPassword)
     checkPassword()
 }
+const handlePasswordCheckFocusout = () => {
+    clearError(passwordCheckInput, errorPasswordCheck)
+    checkPasswordConfirm()
+}
 
 //////////////// 함수 사용////////////////////
 
@@ -82,3 +96,5 @@ const handlePasswordFocusout = () => {
 emailInput.addEventListener('focusout', handleEmailFocusout)
 // 비번 이벤트 리스너 부여
 passwordInput.addEventListener('focusout', handlePasswordFocusout)
+// 비번 확인 이벤트 리스너 부여
+passwordCheckInput.addEventListener('focusout', handlePasswordCheckFocusout)

--- a/javascript/user-data.js
+++ b/javascript/user-data.js
@@ -1,0 +1,6 @@
+/**
+ * codeit 계정 정보
+ */
+const codeit = { email: 'test@codeit.com', password: 'codeit101' }
+
+export { codeit }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- css 태그와 javascript 태그의 원활한 사용을 위해 class와 id 태그 분리

## 스크린샷

![스크린샷](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/155596644/9b65db42-2896-40a3-bef6-119948f64379)

[회원 가입 링크](https://linkbrary-online.netlify.app/html/signup)

## 멘토에게

- 멘토님께서 멘토링 때 세세하고 디테일하게 잘 봐주셔서 이번엔 없네요ㅎㅎㅎ 추후 코드 리뷰나 멘토링 통해서 질문 이어가겠습니다.

