### PR TITLE
[김예진] Week5

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       name="twitter:description"
       content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요"
     />
-    <meta name="twitter:image" content="publicimages/maltese.jpg" />
+    <meta name="twitter:image" content="public/images/maltese.jpg" />
     <link
       rel="stylesheet"
       type="text/css"

--- a/public/styles/sign.css
+++ b/public/styles/sign.css
@@ -73,7 +73,7 @@ a {
 
   position: absolute;
   top: 3rem;
-  left: 23rem;
+  right: 1.5rem;
 
   cursor: pointer;
 }

--- a/signin.html
+++ b/signin.html
@@ -46,6 +46,6 @@
         </div>
       </div>
     </main>
-    <script src="src/sign.js" type="module"></script>
+    <script src="src/signIn.js" type="module"></script>
   </body>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -18,6 +18,7 @@
           <div>
             <label for="email">이메일</label>
             <input id="email" class="signInput" type="email" name="email" />
+            <p class="errorMsg"></p>
           </div>
           <div class="password-form">
             <label for="password">비밀번호</label>
@@ -27,6 +28,7 @@
               type="password"
               name="password"
             />
+            <p class="errorMsg"></p>
             <img class="eye" />
           </div>
           <button>로그인</button>
@@ -44,6 +46,6 @@
         </div>
       </div>
     </main>
-    <script src="src/sign.js"></script>
+    <script src="src/sign.js" type="module"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -18,8 +18,9 @@
           <div>
             <label for="email">이메일</label>
             <input id="email" class="signInput" type="email" name="email" />
+            <p class="errorMsg"></p>
           </div>
-          <div>
+          <div class="password-form signUp">
             <label for="password">비밀번호</label>
             <input
               id="password"
@@ -27,8 +28,10 @@
               type="password"
               name="password"
             />
+            <p class="errorMsg"></p>
+            <img class="eye" id="eye-password" />
           </div>
-          <div>
+          <div class="password-form signUp">
             <label for="password-check">비밀번호 확인</label>
             <input
               id="password-check"
@@ -36,7 +39,10 @@
               type="password"
               name="password-check"
             />
+            <p class="errorMsg"></p>
+            <img class="eye" id="eye-password-check" />
           </div>
+
           <button>회원가입</button>
         </form>
       </div>
@@ -52,6 +58,6 @@
         </div>
       </div>
     </main>
-    <script src="src/sign.js"></script>
+    <script src="src/signUp.js" type="module"></script>
   </body>
 </html>

--- a/src/constant.js
+++ b/src/constant.js
@@ -2,14 +2,22 @@ export const ERROR_MESSAGE = {
   NO_INPUT_EMAIL: "이메일을 입력해 주세요.",
   NO_INPUT_PASSWORD: "비밀번호를 입력해 주세요.",
   INVALID_EMAIL: "올바른 이메일 주소가 아닙니다.",
+  INVALID_PASSWORD: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+  DO_NOT_MATCH_PASSWORD: "비밀번호가 일치하지 않습니다.",
 
+  REGISTERED_EMAIL: "이미 사용 중인 이메일입니다.",
   CONFIRM_EMAIL: "이메일을 확인해 주세요.",
   CONFIRM_PASSWORD: "비밀번호를 확인해 주세요.",
 };
 
-export const emailCheck = (isValidEmail) => {
+export const emailCheck = (confirmEmail) => {
   const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
-  return !email_regex.test(isValidEmail) ? false : true;
+  return !email_regex.test(confirmEmail) ? false : true;
+};
+
+export const passwordCheck = (confirmPassword) => {
+  const password_regax = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
+  return !password_regax.test(confirmPassword) ? false : true;
 };
 
 export const TEST_USER = {

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,18 @@
+export const ERROR_MESSAGE = {
+  NO_INPUT_EMAIL: "이메일을 입력해 주세요.",
+  NO_INPUT_PASSWORD: "비밀번호를 입력해 주세요.",
+  INVALID_EMAIL: "올바른 이메일 주소가 아닙니다.",
+
+  CONFIRM_EMAIL: "이메일을 확인해 주세요.",
+  CONFIRM_PASSWORD: "비밀번호를 확인해 주세요.",
+};
+
+export const emailCheck = (isValidEmail) => {
+  const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+  return !email_regex.test(isValidEmail) ? false : true;
+};
+
+export const TEST_USER = {
+  ID: "test@codeit.com",
+  PASSWORD: "codeit101",
+};

--- a/src/sign.js
+++ b/src/sign.js
@@ -1,70 +1,64 @@
-const form = document.querySelector(".sign-form");
-const email = document.querySelector("#email");
-const password = document.querySelector("#password");
+import { ERROR_MESSAGE, TEST_USER, emailCheck } from "./constant.js";
 
-const pEmail = document.createElement("p");
-const pPwd = document.createElement("p");
-
-const testEmail = "test@codeit.com";
-const testPwd = "codeit101";
-
+const formElement = document.querySelector(".sign-form");
+const emailElement = document.getElementById("email");
+const passwordElement = document.getElementById("password");
 const eyeImg = document.querySelector(".eye");
 
-function reset_Ptag() {
-  email.after(pEmail);
-  pEmail.classList.add("errorMsg");
-  password.after(pPwd);
-  pPwd.classList.add("errorMsg");
-}
+const focusOutHandler = (e) => {
+  const currentInput = e.target;
+  const currentValue = currentInput.value;
+  const currentClassList = currentInput.classList;
+  const errorMsgElement = currentInput.nextElementSibling;
 
-function focusOutEmail() {
-  if (!email.value) {
-    pEmail.textContent = "이메일을 입력해 주세요.";
-    email.classList.add("errorInput");
-  } else if (!email.value.includes("@")) {
-    pEmail.textContent = "올바른 이메일 주소가 아닙니다.";
-    email.classList.add("errorInput");
+  const isEmail = currentInput.type === "email";
+  const noInputText = isEmail
+    ? ERROR_MESSAGE.NO_INPUT_EMAIL
+    : ERROR_MESSAGE.NO_INPUT_PASSWORD;
+
+  if (!currentValue) {
+    currentClassList.add("errorInput");
+    errorMsgElement.textContent = noInputText;
+  } else if (isEmail && !emailCheck(currentValue)) {
+    currentClassList.add("errorInput");
+    errorMsgElement.textContent = ERROR_MESSAGE.INVALID_EMAIL;
   } else {
-    pEmail.remove();
-    email.classList.remove("errorInput");
+    currentClassList.remove("errorInput");
+    errorMsgElement.textContent = "";
   }
-}
+};
 
-function focusOutPwd() {
-  if (!password.value) {
-    pPwd.textContent = "비밀번호를 입력해 주세요.";
-    password.classList.add("errorInput");
-  } else {
-    pPwd.remove();
-    password.classList.remove("errorInput");
-  }
-}
+const submitForm = (e) => {
+  const emailInput = e.target[0];
+  const passwordInput = e.target[1];
 
-function submitForm(e) {
   e.preventDefault();
-  reset_Ptag();
-  if (email.value === testEmail && password.value === testPwd) {
+  console.log();
+  if (
+    emailInput.value === TEST_USER.ID &&
+    passwordInput.value === TEST_USER.PASSWORD
+  ) {
     window.location.href = "/folder";
-    email.value = "";
   } else {
-    pEmail.textContent = "이메일을 확인해 주세요.";
-    pPwd.textContent = "비밀번호를 확인해 주세요.";
-    email.classList.add("errorInput");
-    password.classList.add("errorInput");
+    emailInput.nextElementSibling.textContent = ERROR_MESSAGE.CONFIRM_EMAIL;
+    passwordInput.nextElementSibling.textContent =
+      ERROR_MESSAGE.CONFIRM_PASSWORD;
+    emailInput.classList.add("errorInput");
+    passwordInput.classList.add("errorInput");
   }
-}
+};
 
-function eyeClickHandler() {
+const eyeClickHandler = () => {
   eyeImg.classList.toggle("on");
   if (eyeImg.classList.contains("on")) {
     password.removeAttribute("type");
   } else {
     password.setAttribute("type", "password");
   }
-}
+};
 
-reset_Ptag();
-email.addEventListener("focusout", focusOutEmail);
-password.addEventListener("focusout", focusOutPwd);
-form.addEventListener("submit", submitForm);
+emailElement.addEventListener("focusout", focusOutHandler);
+passwordElement.addEventListener("focusout", focusOutHandler);
+
+formElement.addEventListener("submit", submitForm);
 eyeImg.addEventListener("click", eyeClickHandler);

--- a/src/sign.js
+++ b/src/sign.js
@@ -1,64 +1,114 @@
-import { ERROR_MESSAGE, TEST_USER, emailCheck } from "./constant.js";
+import {
+  ERROR_MESSAGE,
+  TEST_USER,
+  emailCheck,
+  passwordCheck,
+} from "./constant.js";
 
-const formElement = document.querySelector(".sign-form");
-const emailElement = document.getElementById("email");
-const passwordElement = document.getElementById("password");
-const eyeImg = document.querySelector(".eye");
+const setErrorMessage = (currentElement, errorMsg) => {
+  currentElement.classList.add("errorInput");
+  currentElement.nextElementSibling.textContent = errorMsg;
+};
+const removeErrorMessage = (currentElement) => {
+  currentElement.classList.remove("errorInput");
+  currentElement.nextElementSibling.textContent = "";
+};
 
-const focusOutHandler = (e) => {
-  const currentInput = e.target;
-  const currentValue = currentInput.value;
-  const currentClassList = currentInput.classList;
-  const errorMsgElement = currentInput.nextElementSibling;
-
-  const isEmail = currentInput.type === "email";
-  const noInputText = isEmail
-    ? ERROR_MESSAGE.NO_INPUT_EMAIL
-    : ERROR_MESSAGE.NO_INPUT_PASSWORD;
-
-  if (!currentValue) {
-    currentClassList.add("errorInput");
-    errorMsgElement.textContent = noInputText;
-  } else if (isEmail && !emailCheck(currentValue)) {
-    currentClassList.add("errorInput");
-    errorMsgElement.textContent = ERROR_MESSAGE.INVALID_EMAIL;
-  } else {
-    currentClassList.remove("errorInput");
-    errorMsgElement.textContent = "";
+const noInputValue = (currentElement) => {
+  const noInputText =
+    currentElement.type === "email"
+      ? ERROR_MESSAGE.NO_INPUT_EMAIL
+      : ERROR_MESSAGE.NO_INPUT_PASSWORD;
+  if (!currentElement.value) {
+    setErrorMessage(currentElement, noInputText);
   }
 };
 
-const submitForm = (e) => {
-  const emailInput = e.target[0];
-  const passwordInput = e.target[1];
+const isValidEmail = (currentElement) => {
+  if (!emailCheck(currentElement.value)) {
+    setErrorMessage(currentElement, ERROR_MESSAGE.INVALID_EMAIL);
+  } else {
+    removeErrorMessage(currentElement);
+  }
+};
+const isValidPassword = (currentElement) => {
+  if (!passwordCheck(currentElement.value)) {
+    setErrorMessage(currentElement, ERROR_MESSAGE.INVALID_PASSWORD);
+  } else {
+    removeErrorMessage(currentElement);
+  }
+};
 
-  e.preventDefault();
-  console.log();
-  if (
-    emailInput.value === TEST_USER.ID &&
-    passwordInput.value === TEST_USER.PASSWORD
-  ) {
+const confirmEmail = (currentElement) => {
+  if (currentElement.value === TEST_USER.ID) {
+    setErrorMessage(currentElement, ERROR_MESSAGE.REGISTERED_EMAIL);
+  }
+};
+const confirmPasswordMatch = (currentElement) => {
+  const passwordElement = document.getElementById("password");
+
+  if (currentElement.value !== passwordElement.value) {
+    setErrorMessage(currentElement, ERROR_MESSAGE.DO_NOT_MATCH_PASSWORD);
+  } else {
+    removeErrorMessage(currentElement);
+  }
+};
+const confirmUserLogin = (currentElement) => {
+  const email = currentElement[0];
+  const password = currentElement[1];
+
+  if (email.value === TEST_USER.ID && password.value === TEST_USER.PASSWORD) {
     window.location.href = "/folder";
   } else {
-    emailInput.nextElementSibling.textContent = ERROR_MESSAGE.CONFIRM_EMAIL;
-    passwordInput.nextElementSibling.textContent =
-      ERROR_MESSAGE.CONFIRM_PASSWORD;
-    emailInput.classList.add("errorInput");
-    passwordInput.classList.add("errorInput");
+    setErrorMessage(email, ERROR_MESSAGE.CONFIRM_EMAIL);
+    setErrorMessage(password, ERROR_MESSAGE.CONFIRM_PASSWORD);
+  }
+};
+const confirmForm = (currentForm) => {
+  const emailElement = currentForm[0];
+  const passwordElement = currentForm[1];
+  const passwordConfirmElement = currentForm[2];
+
+  if (!emailCheck(emailElement.value) || emailElement.value === TEST_USER.ID) {
+    setErrorMessage(emailElement, ERROR_MESSAGE.CONFIRM_EMAIL);
+  }
+  if (!passwordCheck(passwordElement.value)) {
+    setErrorMessage(password, ERROR_MESSAGE.CONFIRM_PASSWORD);
+  }
+  if (passwordElement.value !== passwordConfirmElement.value) {
+    setErrorMessage(passwordConfirmElement, ERROR_MESSAGE.CONFIRM_PASSWORD);
   }
 };
 
-const eyeClickHandler = () => {
-  eyeImg.classList.toggle("on");
-  if (eyeImg.classList.contains("on")) {
-    password.removeAttribute("type");
+const confirmUserRegister = (currentElement) => {
+  confirmForm(currentElement);
+  const elementsArr = [...currentElement];
+  const satisfy = elementsArr.some((element) =>
+    element.classList.contains("errorInput")
+  );
+  if (!satisfy) {
+    window.location.href = "/folder";
+  }
+};
+
+const eyeClickHandler = (e) => {
+  const currentPassword = e.target.parentElement.children[1];
+  e.target.classList.toggle("on");
+  if (e.target.classList.contains("on")) {
+    currentPassword.removeAttribute("type");
   } else {
-    password.setAttribute("type", "password");
+    currentPassword.setAttribute("type", "password");
   }
 };
 
-emailElement.addEventListener("focusout", focusOutHandler);
-passwordElement.addEventListener("focusout", focusOutHandler);
-
-formElement.addEventListener("submit", submitForm);
-eyeImg.addEventListener("click", eyeClickHandler);
+export {
+  noInputValue,
+  isValidEmail,
+  isValidPassword,
+  confirmEmail,
+  confirmPasswordMatch,
+  confirmUserLogin,
+  confirmUserRegister,
+  eyeClickHandler,
+  removeErrorMessage,
+};

--- a/src/signIn.js
+++ b/src/signIn.js
@@ -1,0 +1,34 @@
+import {
+  noInputValue,
+  isValidEmail,
+  removeErrorMessage,
+  confirmUserLogin,
+  eyeClickHandler,
+} from "./sign.js";
+
+const formElement = document.querySelector(".sign-form");
+const emailElement = document.getElementById("email");
+const passwordElement = document.getElementById("password");
+const eyePassword = document.querySelector(".eye");
+
+const focusOutHandler = (e) => {
+  const currentInput = e.target;
+  if (!currentInput.value) {
+    noInputValue(currentInput); //값이 없는지 확인
+  } else if (currentInput.type === "email") {
+    isValidEmail(currentInput); //이메일 유효성 체크
+  } else {
+    removeErrorMessage(currentInput);
+  }
+};
+
+const submitLoginForm = (e) => {
+  e.preventDefault();
+  confirmUserLogin(e.target);
+};
+
+emailElement.addEventListener("focusout", focusOutHandler);
+passwordElement.addEventListener("focusout", focusOutHandler);
+
+formElement.addEventListener("submit", submitLoginForm);
+eyePassword.addEventListener("click", eyeClickHandler);

--- a/src/signUp.js
+++ b/src/signUp.js
@@ -1,0 +1,47 @@
+import {
+  noInputValue,
+  isValidEmail,
+  isValidPassword,
+  confirmEmail,
+  confirmPasswordMatch,
+  confirmUserRegister,
+  eyeClickHandler,
+} from "./sign.js";
+
+const formElement = document.querySelector(".sign-form");
+const emailElement = document.getElementById("email");
+const passwordElement = document.getElementById("password");
+const passwordConfirmElement = document.getElementById("password-check");
+const eyePassword = document.getElementById("eye-password");
+const eyePasswordCheck = document.getElementById("eye-password-check");
+
+const focusOutHandler = (e) => {
+  const currentInput = e.target;
+  const isEmail = currentInput.type === "email";
+  const isPassword = currentInput.id === "password";
+  const isPasswordConfirm = currentInput.id === "password-check";
+
+  if (!currentInput.value) {
+    noInputValue(currentInput); //값이 없는지 확인
+  } else if (isEmail) {
+    isValidEmail(currentInput); //이메일 유효성 체크
+    confirmEmail(currentInput); //사용중인 이메일인지 확인
+  } else if (isPassword) {
+    isValidPassword(currentInput); //비밀번호 유효성 체크
+  } else if (isPasswordConfirm) {
+    confirmPasswordMatch(currentInput); //비밀번호와 비밀번호 확인 일치 확인
+  }
+};
+
+const submitRegisterForm = (e) => {
+  e.preventDefault();
+  confirmUserRegister(e.target);
+};
+
+emailElement.addEventListener("focusout", focusOutHandler);
+passwordElement.addEventListener("focusout", focusOutHandler);
+passwordConfirmElement.addEventListener("focusout", focusOutHandler);
+
+formElement.addEventListener("submit", submitRegisterForm);
+eyePassword.addEventListener("click", eyeClickHandler);
+eyePasswordCheck.addEventListener("click", eyeClickHandler);


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x]  이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x]  비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x]  비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x]  회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x]  이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x]  회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x]  이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x]  눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x]  비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x]  로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항
회원가입 페이지
- 이메일, 비밀번호 확인 에러메세지
- 이메일, 비밀번호 유효성 확인 메세지
- 비밀번호와 비밀번호 확인 일치 검증

js 파일
- constant.js에 상수를 담는 모듈 분리
- sign.js에 주요 함수 외 함수들 모듈 분리
- 이메일, 비밀번호 핸들러 한번에 관리

## 스크린샷

[사이트 링크](https://ggjiny-weekly-mission.netlify.app/)

## 멘토에게

- signIn.js, signUp.js에서는 주요 기능이라고 생각되는 focusout, submit 이벤트를 다루는 함수들만 작성하고, sign.js에 로그인, 회원가입에서 공통적으로 사용하는 함수들 뿐만 아니라 그 외 함수들도 모두 모아놓고 필요한 함수만 가져다가 사용했는데요, 이렇게 모듈을 분리하는 방법이 괜찮을지 더 나은 방법이 있다면 어떻게 하는게 좋을지 궁금합니다.
- 함수 하나하나를 최대한 작은 단위, 순수함수로 만들기 위해 노력했는데 부족한 부분이 있으면 말씀 부탁드립니다!
- 멘토링 시간에 배우는게 많습니다!! 항상 열심히 준비해와주시고 질문도 잘 받아주시고 정보 공유 많이 해주셔서 감사합니다👏👏
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
