### PR TITLE
[남현준] week5

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,0 +1,6 @@
+export const isValidEmail = (emailInput) => {
+  const email_regex =
+    /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
+
+  return email_regex.test(emailInput);
+};

--- a/common.js
+++ b/common.js
@@ -4,3 +4,23 @@ export const isValidEmail = (emailInput) => {
 
   return email_regex.test(emailInput);
 };
+
+export const printEmailError = (emailMessage, emailInput) => {
+  emailMessage.classList.remove("error-style");
+  if (emailInput.value.length === 0) {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "이메일을 입력해주세요.";
+    emailInput.style.border = "1px solid #ff5b45";
+  } else if (!isValidEmail(emailInput.value)) {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
+    emailInput.style.border = "1px solid #ff5b45";
+  } else if (emailInput.value === "test@codeit.com") {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "이미 사용 중인 이메일입니다.";
+    emailInput.style.border = "1px solid #ff5b45";
+  } else {
+    emailMessage.classList.add("error-style");
+    return true;
+  }
+};

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+import { isValidEmail } from "./common.js";
+
 const emailInput = document.querySelector(".email-input");
 const emailError = document.createElement("div");
 
@@ -9,57 +11,59 @@ passwordError.classList.add("error-message");
 const eyeBtn = document.querySelector(".eye-button");
 const loginBtn = document.querySelector(".cta");
 
-const isValidEmail = () => {
-  const email_regex =
-    /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
-
-  if (email_regex.test(emailInput.value)) {
-    return true;
-  } else {
-    return false;
-  }
-};
 const isValidAccount = (event) => {
   event.preventDefault();
   if (
-    updateEmail() === "test@codeit.com" &&
+    emailInput.value === "test@codeit.com" &&
     passwordInput.value === "codeit101"
   ) {
     location.href = "./folder.html";
   } else if (
-    updateEmail() !== "test@codeit.com" &&
-    updatePassword() === "codeit101"
+    emailInput.value !== "test@codeit.com" &&
+    passwordInput.value === "codeit101"
   ) {
-    emailInput.after(emailError);
-    emailError.textContent = "이메일을 확인해 주세요.";
-    emailInput.style.border = "1px solid #ff5b45";
+    isNotValidEmail();
   } else if (
-    updateEmail() === "test@codeit.com" &&
-    updatePassword() !== "codeit101"
+    emailInput.value === "test@codeit.com" &&
+    passwordInput.value !== "codeit101"
   ) {
-    passwordInput.after(passwordError);
-    passwordError.textContent = "비밀번호를 확인해 주세요.";
-    passwordInput.style.border = "1px solid #ff5b45";
+    isNotValidPassword();
   } else if (
-    updateEmail() !== "test@codeit.com" &&
-    updatePassword() !== "codeit101"
+    emailInput.value !== "test@codeit.com" &&
+    passwordInput.value !== "codeit101"
   ) {
-    emailInput.after(emailError);
-    emailError.textContent = "이메일을 확인해 주세요.";
-    passwordInput.after(passwordError);
-    passwordError.textContent = "비밀번호를 확인해 주세요.";
-    emailInput.style.border = "1px solid #ff5b45";
-    passwordInput.style.border = "1px solid #ff5b45";
+    isNotValidAll();
   }
 };
+const isNotValidEmail = () => {
+  emailInput.after(emailError);
+  emailError.textContent = "이메일을 확인해 주세요.";
+  emailInput.style.border = "1px solid #ff5b45";
+};
 
+const isNotValidPassword = () => {
+  passwordInput.after(passwordError);
+  passwordError.textContent = "비밀번호를 확인해 주세요.";
+  passwordInput.style.border = "1px solid #ff5b45";
+};
+const isNotValidAll = () => {
+  emailInput.after(emailError);
+  emailError.textContent = "이메일을 확인해 주세요.";
+  passwordInput.after(passwordError);
+  passwordError.textContent = "비밀번호를 확인해 주세요.";
+  emailInput.style.border = "1px solid #ff5b45";
+  passwordInput.style.border = "1px solid #ff5b45";
+};
 const focusoutEmail = (event) => {
   if (event.target.value.length === 0) {
     emailInput.after(emailError);
     emailError.textContent = "이메일을 입력해 주세요.";
-  } else if (event.target.value.length !== 0 && isValidEmail()) {
+  } else if (
+    event.target.value.length !== 0 &&
+    isValidEmail(emailInput.value)
+  ) {
     emailError.remove();
-  } else if (!isValidEmail()) {
+  } else if (!isValidEmail(emailInput.value)) {
     emailInput.after(emailError);
     emailError.textContent = "올바른 이메일 주소가 아닙니다.";
   }
@@ -78,10 +82,7 @@ const showPw = () => {
   eyeBtn.style.display = "none";
 };
 
-emailInput.addEventListener("input", updateEmail);
 emailInput.addEventListener("focusout", focusoutEmail);
-
-passwordInput.addEventListener("input", updatePassword);
 passwordInput.addEventListener("focusout", focusoutPassword);
 
 eyeBtn.addEventListener("click", showPw);

--- a/index.js
+++ b/index.js
@@ -9,18 +9,11 @@ passwordError.classList.add("error-message");
 const eyeBtn = document.querySelector(".eye-button");
 const loginBtn = document.querySelector(".cta");
 
-const updateEmail = () => {
-  return emailInput.value;
-};
-const updatePassword = () => {
-  return passwordInput.value;
-};
 const isValidEmail = () => {
   const email_regex =
     /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
 
-  const emailValue = updateEmail();
-  if (email_regex.test(emailValue)) {
+  if (email_regex.test(emailInput.value)) {
     return true;
   } else {
     return false;
@@ -28,7 +21,10 @@ const isValidEmail = () => {
 };
 const isValidAccount = (event) => {
   event.preventDefault();
-  if (updateEmail() === "test@codeit.com" && updatePassword() === "codeit101") {
+  if (
+    updateEmail() === "test@codeit.com" &&
+    passwordInput.value === "codeit101"
+  ) {
     location.href = "./folder.html";
   } else if (
     updateEmail() !== "test@codeit.com" &&

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-import { isValidEmail } from "./common.js";
+import { printEmailError } from "./common.js";
 
 const emailInput = document.querySelector(".email-input");
-const emailError = document.createElement("div");
+const emailMessage = document.createElement("div");
 
 const passwordInput = document.querySelector(".password-input");
 const passwordError = document.createElement("div");
 
-emailError.classList.add("error-message");
+emailMessage.classList.add("error-message");
 passwordError.classList.add("error-message");
 const eyeBtn = document.querySelector(".eye-button");
 const loginBtn = document.querySelector(".cta");
@@ -36,8 +36,8 @@ const handleClickBtn = (event) => {
   }
 };
 const displayEmailError = () => {
-  emailInput.after(emailError);
-  emailError.textContent = "이메일을 확인해 주세요.";
+  emailInput.after(emailMessage);
+  emailMessage.textContent = "이메일을 확인해 주세요.";
   emailInput.style.border = "1px solid #ff5b45";
 };
 
@@ -51,24 +51,14 @@ const displayAllErrors = () => {
   displayPwError();
 };
 const handleFocusoutEmail = (event) => {
-  if (event.target.value.length === 0) {
-    emailInput.after(emailError);
-    emailError.textContent = "이메일을 입력해 주세요.";
-  } else if (
-    event.target.value.length !== 0 &&
-    isValidEmail(emailInput.value)
-  ) {
-    emailError.remove();
-  } else if (!isValidEmail(emailInput.value)) {
-    emailInput.after(emailError);
-    emailError.textContent = "올바른 이메일 주소가 아닙니다.";
-  }
+  printEmailError(emailMessage, emailInput);
 };
 
 const handleFocusoutPw = (event) => {
   if (event.target.value.length === 0) {
     passwordInput.after(passwordError);
     passwordError.textContent = "비밀번호를 입력해 주세요.";
+    passwordInput.style.border = "1px solid #ff5b45";
   } else {
     passwordError.remove();
   }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ passwordError.classList.add("error-message");
 const eyeBtn = document.querySelector(".eye-button");
 const loginBtn = document.querySelector(".cta");
 
-const isValidAccount = (event) => {
+const handleClickBtn = (event) => {
   event.preventDefault();
   if (
     emailInput.value === "test@codeit.com" &&
@@ -22,39 +22,35 @@ const isValidAccount = (event) => {
     emailInput.value !== "test@codeit.com" &&
     passwordInput.value === "codeit101"
   ) {
-    isNotValidEmail();
+    displayEmailError();
   } else if (
     emailInput.value === "test@codeit.com" &&
     passwordInput.value !== "codeit101"
   ) {
-    isNotValidPassword();
+    displayPwError();
   } else if (
     emailInput.value !== "test@codeit.com" &&
     passwordInput.value !== "codeit101"
   ) {
-    isNotValidAll();
+    displayAllErrors();
   }
 };
-const isNotValidEmail = () => {
+const displayEmailError = () => {
   emailInput.after(emailError);
   emailError.textContent = "이메일을 확인해 주세요.";
   emailInput.style.border = "1px solid #ff5b45";
 };
 
-const isNotValidPassword = () => {
+const displayPwError = () => {
   passwordInput.after(passwordError);
   passwordError.textContent = "비밀번호를 확인해 주세요.";
   passwordInput.style.border = "1px solid #ff5b45";
 };
-const isNotValidAll = () => {
-  emailInput.after(emailError);
-  emailError.textContent = "이메일을 확인해 주세요.";
-  passwordInput.after(passwordError);
-  passwordError.textContent = "비밀번호를 확인해 주세요.";
-  emailInput.style.border = "1px solid #ff5b45";
-  passwordInput.style.border = "1px solid #ff5b45";
+const displayAllErrors = () => {
+  displayEmailError();
+  displayPwError();
 };
-const focusoutEmail = (event) => {
+const handleFocusoutEmail = (event) => {
   if (event.target.value.length === 0) {
     emailInput.after(emailError);
     emailError.textContent = "이메일을 입력해 주세요.";
@@ -69,7 +65,7 @@ const focusoutEmail = (event) => {
   }
 };
 
-const focusoutPassword = (event) => {
+const handleFocusoutPw = (event) => {
   if (event.target.value.length === 0) {
     passwordInput.after(passwordError);
     passwordError.textContent = "비밀번호를 입력해 주세요.";
@@ -77,13 +73,13 @@ const focusoutPassword = (event) => {
     passwordError.remove();
   }
 };
-const showPw = () => {
+const handleClickEyes = () => {
   passwordInput.setAttribute("type", "text");
   eyeBtn.style.display = "none";
 };
 
-emailInput.addEventListener("focusout", focusoutEmail);
-passwordInput.addEventListener("focusout", focusoutPassword);
+emailInput.addEventListener("focusout", handleFocusoutEmail);
+passwordInput.addEventListener("focusout", handleFocusoutPw);
 
-eyeBtn.addEventListener("click", showPw);
-loginBtn.addEventListener("click", isValidAccount);
+eyeBtn.addEventListener("click", handleClickEyes);
+loginBtn.addEventListener("click", handleClickBtn);

--- a/signin.html
+++ b/signin.html
@@ -66,6 +66,6 @@
         </div>
       </div>
     </div>
-    <script src="index.js"></script>
+    <script type="module" src="index.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -41,7 +41,7 @@
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" />
+            <input class="sign-input check-password" type="password" />
             <button class="eye-button" type="button">
               <img src="./images/eye-off.svg" />
             </button>

--- a/signup.html
+++ b/signup.html
@@ -34,7 +34,7 @@
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" />
+            <input class="sign-input password-input" type="password" />
             <button class="eye-button" type="button">
               <img src="./images/eye-off.svg" />
             </button>

--- a/signup.html
+++ b/signup.html
@@ -13,10 +13,16 @@
   <body>
     <header>
       <a class="logo-link" href="index.html">
-        <img class="header-logo" src="./images/logo.svg" alt="홈으로 연결된 Linkbrary 로고" />
+        <img
+          class="header-logo"
+          src="./images/logo.svg"
+          alt="홈으로 연결된 Linkbrary 로고"
+        />
       </a>
       <p class="header-message">
-        이미 회원이신가요?<a class="header-link" href="signin.html">로그인 하기</a>
+        이미 회원이신가요?<a class="header-link" href="signin.html"
+          >로그인 하기</a
+        >
       </p>
     </header>
     <div class="sign-box">
@@ -24,7 +30,7 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" />
+            <input class="sign-input email-input" />
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
@@ -55,5 +61,6 @@
         </div>
       </div>
     </div>
+    <script src="signup.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -61,6 +61,6 @@
         </div>
       </div>
     </div>
-    <script src="signup.js"></script>
+    <script type="module" src="signup.js"></script>
   </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -7,6 +7,9 @@ const passwordMessage = document.createElement("div");
 const rePasswordMessage = document.createElement("div");
 const eyeBtn = document.querySelectorAll(".eye-button");
 
+emailMessage.classList.add("error-message");
+passwordMessage.classList.add("error-message");
+
 import { isValidEmail } from "./common.js";
 
 const handleFocusoutEmail = () => {

--- a/signup.js
+++ b/signup.js
@@ -1,8 +1,11 @@
 const emailInput = document.querySelector(".email-input");
 const passwordInput = document.querySelector(".password-input");
+const rePasswordInput = document.querySelector(".check-password");
 const form = document.querySelector(".sign-form");
 const emailMessage = document.createElement("div");
 const passwordMessage = document.createElement("div");
+const rePasswordMessage = document.createElement("div");
+
 const isValidEmail = (e) => {
   const email_regex =
     /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
@@ -17,14 +20,10 @@ const handleFocusoutEmail = (e) => {
   if (e.target.value.length === 0) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이메일을 입력해주세요.";
-  }
-
-  if (!isValidEmail()) {
+  } else if (!isValidEmail()) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
-  }
-
-  if (e.target.value === "test@codeit.com") {
+  } else if (e.target.value === "test@codeit.com") {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이미 사용 중인 이메일입니다.";
   } else {
@@ -37,7 +36,6 @@ const strongPassword = (str) => {
 };
 
 const handleFocusoutPassword = (e) => {
-  console.log(e.target.value);
   if (!strongPassword(e.target.value)) {
     passwordInput.after(passwordMessage);
     passwordMessage.textContent =
@@ -46,5 +44,15 @@ const handleFocusoutPassword = (e) => {
     passwordMessage.classList.add("error-style");
   }
 };
+
+const handleFocusoutRePassword = (e) => {
+  if (e.target.value !== passwordInput.value) {
+    rePasswordInput.after(rePasswordMessage);
+    rePasswordMessage.textContent = "비밀번호가 일치하지 않아요.";
+  } else {
+    rePasswordMessage.classList.add("error-style");
+  }
+};
 emailInput.addEventListener("focusout", handleFocusoutEmail);
 passwordInput.addEventListener("focusout", handleFocusoutPassword);
+rePasswordInput.addEventListener("focusout", handleFocusoutRePassword);

--- a/signup.js
+++ b/signup.js
@@ -1,3 +1,5 @@
+import { printEmailError } from "./common.js";
+
 const emailInput = document.querySelector(".email-input");
 const passwordInput = document.querySelector(".password-input");
 const rePasswordInput = document.querySelector(".check-password");
@@ -9,24 +11,10 @@ const eyeBtn = document.querySelectorAll(".eye-button");
 
 emailMessage.classList.add("error-message");
 passwordMessage.classList.add("error-message");
-
-import { isValidEmail } from "./common.js";
+rePasswordMessage.classList.add("error-message");
 
 const handleFocusoutEmail = () => {
-  emailMessage.classList.remove("error-style");
-  if (emailInput.value.length === 0) {
-    emailInput.after(emailMessage);
-    emailMessage.textContent = "이메일을 입력해주세요.";
-  } else if (!isValidEmail(emailInput.value)) {
-    emailInput.after(emailMessage);
-    emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
-  } else if (emailInput.value === "test@codeit.com") {
-    emailInput.after(emailMessage);
-    emailMessage.textContent = "이미 사용 중인 이메일입니다.";
-  } else {
-    emailMessage.classList.add("error-style");
-    return true;
-  }
+  printEmailError(emailMessage, emailInput);
 };
 
 const isValidPassword = (str) => {
@@ -39,6 +27,7 @@ const handleFocusoutPassword = () => {
     passwordInput.after(passwordMessage);
     passwordMessage.textContent =
       "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.";
+    passwordInput.style.border = "1px solid #ff5b45";
   } else {
     passwordMessage.classList.add("error-style");
     return true;
@@ -50,6 +39,7 @@ const handleFocusoutRePassword = () => {
   if (rePasswordInput.value !== passwordInput.value) {
     rePasswordInput.after(rePasswordMessage);
     rePasswordMessage.textContent = "비밀번호가 일치하지 않아요.";
+    rePasswordInput.style.border = "1px solid #ff5b45";
   } else {
     rePasswordMessage.classList.add("error-style");
     return true;

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,33 @@
+const emailInput = document.querySelector(".email-input");
+const form = document.querySelector(".sign-form");
+const emailMessage = document.createElement("div");
+
+const isValidEmail = (e) => {
+  const email_regex =
+    /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
+
+  if (email_regex.test(emailInput.value)) {
+    return true;
+  } else {
+    return false;
+  }
+};
+const handleFocusoutEmail = (e) => {
+  if (e.target.value.length === 0) {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "이메일을 입력해주세요.";
+    emailMessage.classList = "email-message";
+  }
+
+  if (!isValidEmail()) {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
+  }
+
+  if (e.target.value === "test@codeit.com") {
+    emailInput.after(emailMessage);
+    emailMessage.textContent = "이미 사용 중인 이메일입니다.";
+    emailMessage.classList = "email-message";
+  }
+};
+emailInput.addEventListener("focusout", handleFocusoutEmail);

--- a/signup.js
+++ b/signup.js
@@ -7,6 +7,7 @@ const emailMessage = document.createElement("div");
 const passwordMessage = document.createElement("div");
 const rePasswordMessage = document.createElement("div");
 const signupBtn = document.querySelector(".cta");
+const eyeBtn = document.querySelectorAll(".eye-button");
 
 const isValidEmail = () => {
   const email_regex =
@@ -72,7 +73,17 @@ const handleClickBtn = (e) => {
     location.href = "./folder.html";
   }
 };
+const showPw = () => {
+  passwordInput.setAttribute("type", "text");
+  rePasswordInput.setAttribute("type", "text");
+  eyeBtn.forEach((v) => {
+    return (v.style.display = "none");
+  });
+};
+
 emailInput.addEventListener("focusout", handleFocusoutEmail);
 passwordInput.addEventListener("focusout", handleFocusoutPassword);
 rePasswordInput.addEventListener("focusout", handleFocusoutRePassword);
 signupBtn.addEventListener("click", handleClickBtn);
+eyeBtn[0].addEventListener("click", showPw);
+eyeBtn[1].addEventListener("click", showPw);

--- a/signup.js
+++ b/signup.js
@@ -1,29 +1,20 @@
 const emailInput = document.querySelector(".email-input");
 const passwordInput = document.querySelector(".password-input");
 const rePasswordInput = document.querySelector(".check-password");
-const signInput = document.querySelector(".sign-input");
 const form = document.querySelector(".sign-form");
 const emailMessage = document.createElement("div");
 const passwordMessage = document.createElement("div");
 const rePasswordMessage = document.createElement("div");
 const eyeBtn = document.querySelectorAll(".eye-button");
 
-const isValidEmail = () => {
-  const email_regex =
-    /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
+import { isValidEmail } from "./common.js";
 
-  if (email_regex.test(emailInput.value)) {
-    return true;
-  } else {
-    return false;
-  }
-};
 const handleFocusoutEmail = () => {
   emailMessage.classList.remove("error-style");
   if (emailInput.value.length === 0) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이메일을 입력해주세요.";
-  } else if (!isValidEmail()) {
+  } else if (!isValidEmail(emailInput.value)) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
   } else if (emailInput.value === "test@codeit.com") {

--- a/signup.js
+++ b/signup.js
@@ -6,7 +6,6 @@ const form = document.querySelector(".sign-form");
 const emailMessage = document.createElement("div");
 const passwordMessage = document.createElement("div");
 const rePasswordMessage = document.createElement("div");
-const signupBtn = document.querySelector(".cta");
 const eyeBtn = document.querySelectorAll(".eye-button");
 
 const isValidEmail = () => {
@@ -36,13 +35,13 @@ const handleFocusoutEmail = () => {
   }
 };
 
-const strongPassword = (str) => {
+const isValidPassword = (str) => {
   return /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/.test(str);
 };
 
 const handleFocusoutPassword = () => {
   passwordMessage.classList.remove("error-style");
-  if (!strongPassword(passwordInput.value)) {
+  if (!isValidPassword(passwordInput.value)) {
     passwordInput.after(passwordMessage);
     passwordMessage.textContent =
       "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.";
@@ -84,6 +83,6 @@ const showPw = () => {
 emailInput.addEventListener("focusout", handleFocusoutEmail);
 passwordInput.addEventListener("focusout", handleFocusoutPassword);
 rePasswordInput.addEventListener("focusout", handleFocusoutRePassword);
-signupBtn.addEventListener("click", handleClickBtn);
+form.addEventListener("submit", handleClickBtn);
 eyeBtn[0].addEventListener("click", showPw);
 eyeBtn[1].addEventListener("click", showPw);

--- a/signup.js
+++ b/signup.js
@@ -1,7 +1,8 @@
 const emailInput = document.querySelector(".email-input");
+const passwordInput = document.querySelector(".password-input");
 const form = document.querySelector(".sign-form");
 const emailMessage = document.createElement("div");
-
+const passwordMessage = document.createElement("div");
 const isValidEmail = (e) => {
   const email_regex =
     /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
@@ -16,7 +17,6 @@ const handleFocusoutEmail = (e) => {
   if (e.target.value.length === 0) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이메일을 입력해주세요.";
-    emailMessage.classList = "email-message";
   }
 
   if (!isValidEmail()) {
@@ -27,7 +27,24 @@ const handleFocusoutEmail = (e) => {
   if (e.target.value === "test@codeit.com") {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이미 사용 중인 이메일입니다.";
-    emailMessage.classList = "email-message";
+  } else {
+    emailMessage.classList.add("error-style");
+  }
+};
+
+const strongPassword = (str) => {
+  return /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/.test(str);
+};
+
+const handleFocusoutPassword = (e) => {
+  console.log(e.target.value);
+  if (!strongPassword(e.target.value)) {
+    passwordInput.after(passwordMessage);
+    passwordMessage.textContent =
+      "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.";
+  } else {
+    passwordMessage.classList.add("error-style");
   }
 };
 emailInput.addEventListener("focusout", handleFocusoutEmail);
+passwordInput.addEventListener("focusout", handleFocusoutPassword);

--- a/signup.js
+++ b/signup.js
@@ -1,12 +1,14 @@
 const emailInput = document.querySelector(".email-input");
 const passwordInput = document.querySelector(".password-input");
 const rePasswordInput = document.querySelector(".check-password");
+const signInput = document.querySelector(".sign-input");
 const form = document.querySelector(".sign-form");
 const emailMessage = document.createElement("div");
 const passwordMessage = document.createElement("div");
 const rePasswordMessage = document.createElement("div");
+const signupBtn = document.querySelector(".cta");
 
-const isValidEmail = (e) => {
+const isValidEmail = () => {
   const email_regex =
     /^([0-9a-zA-Z_\.-]+)@([0-9a-zA-Z_-]+)(\.[0-9a-zA-Z_-]+){1,2}$/;
 
@@ -16,18 +18,20 @@ const isValidEmail = (e) => {
     return false;
   }
 };
-const handleFocusoutEmail = (e) => {
-  if (e.target.value.length === 0) {
+const handleFocusoutEmail = () => {
+  emailMessage.classList.remove("error-style");
+  if (emailInput.value.length === 0) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이메일을 입력해주세요.";
   } else if (!isValidEmail()) {
     emailInput.after(emailMessage);
     emailMessage.textContent = "올바른 이메일 주소가 아닙니다.";
-  } else if (e.target.value === "test@codeit.com") {
+  } else if (emailInput.value === "test@codeit.com") {
     emailInput.after(emailMessage);
     emailMessage.textContent = "이미 사용 중인 이메일입니다.";
   } else {
     emailMessage.classList.add("error-style");
+    return true;
   }
 };
 
@@ -35,24 +39,40 @@ const strongPassword = (str) => {
   return /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/.test(str);
 };
 
-const handleFocusoutPassword = (e) => {
-  if (!strongPassword(e.target.value)) {
+const handleFocusoutPassword = () => {
+  passwordMessage.classList.remove("error-style");
+  if (!strongPassword(passwordInput.value)) {
     passwordInput.after(passwordMessage);
     passwordMessage.textContent =
       "비밀번호는 영문,숫자 조합 8자 이상 입력해 주세요.";
   } else {
     passwordMessage.classList.add("error-style");
+    return true;
   }
 };
 
-const handleFocusoutRePassword = (e) => {
-  if (e.target.value !== passwordInput.value) {
+const handleFocusoutRePassword = () => {
+  rePasswordMessage.classList.remove("error-style");
+  if (rePasswordInput.value !== passwordInput.value) {
     rePasswordInput.after(rePasswordMessage);
     rePasswordMessage.textContent = "비밀번호가 일치하지 않아요.";
   } else {
     rePasswordMessage.classList.add("error-style");
+    return true;
+  }
+};
+
+const handleClickBtn = (e) => {
+  e.preventDefault();
+  if (
+    handleFocusoutEmail() &&
+    handleFocusoutPassword() &&
+    handleFocusoutRePassword()
+  ) {
+    location.href = "./folder.html";
   }
 };
 emailInput.addEventListener("focusout", handleFocusoutEmail);
 passwordInput.addEventListener("focusout", handleFocusoutPassword);
 rePasswordInput.addEventListener("focusout", handleFocusoutRePassword);
+signupBtn.addEventListener("click", handleClickBtn);

--- a/src/sign.css
+++ b/src/sign.css
@@ -70,6 +70,9 @@ header {
 .error-message {
   color: #ff5b45;
 }
+.error-style {
+  display: none;
+}
 .sign-input-box {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 요구사항

### 기본

- [x]  [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?
-
## 주요 변경사항

-
-

## 스크린샷


## 멘토에게

- signup.js 에서 코드가 비효율적인 느낌이 드는데 어떻게 개선하면 좋을 지 피드백을 받고 싶습니다.
