### PR TITLE
[이진우] Week5

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -13,10 +13,16 @@
   <body>
     <header>
       <a class="logo-link" href="index.html">
-        <img class="header-logo" src="./images/logo.svg" alt="홈으로 연결된 Linkbrary 로고" />
+        <img
+          class="header-logo"
+          src="./images/logo.svg"
+          alt="홈으로 연결된 Linkbrary 로고"
+        />
       </a>
       <p class="header-message">
-        이미 회원이신가요?<a class="header-link" href="signin.html">로그인 하기</a>
+        이미 회원이신가요?<a class="header-link" href="signin.html"
+          >로그인 하기</a
+        >
       </p>
     </header>
     <div class="sign-box">
@@ -24,21 +30,28 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" />
+            <input id="emailInput" class="sign-input" />
+            <p class="error-message"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="./images/eye-off.svg" />
-            </button>
+            <div class="sign-input-box sign-password">
+              <input id="passW" class="sign-input" type="password" />
+              <button class="eye-button" type="button">
+                <img src="./images/eye-off.svg" />
+              </button>
+            </div>
+            <p class="error-message"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="./images/eye-off.svg" />
-            </button>
+            <div class="sign-input-box sign-password">
+              <input id="veriPassW" class="sign-input" type="password" />
+              <button class="eye-button" type="button">
+                <img src="./images/eye-off.svg" />
+              </button>
+            </div>
+            <p class="error-message"></p>
           </div>
         </div>
         <button class="cta" type="submit">회원가입</button>
@@ -55,5 +68,6 @@
         </div>
       </div>
     </div>
+    <script src="signup.js"></script>
   </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,89 @@
+const ALREADY_EXIST_EMAIL = 'test@codeit.com';
+
+const emailInput = document.querySelector('#emailInput');
+const passwordInput = document.querySelector('#passW');
+const passwordConfirmInput = document.querySelector('#veriPassW');
+const form = document.querySelector('.sign-form');
+
+// 이메일 검증 함수
+function validateEmail(email) {
+    const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return regex.test(email);
+}
+
+// 비밀번호 검증 함수
+function validatePassword(password) {
+    const regex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+    return regex.test(password);
+}
+
+// 이메일 입력 필드에 대한 이벤트 리스너
+function checkEmail() {
+    const errorSpan = emailInput.nextElementSibling;
+    errorSpan.hidden = false;
+    emailInput.classList.add('error');
+    console.log(emailInput.value);
+
+    if (!emailInput.value) {
+        errorSpan.textContent = '이메일을 입력해주세요.';
+        return;
+    }
+
+    if (!validateEmail(emailInput.value)) {
+        errorSpan.textContent = '올바른 이메일 주소가 아닙니다.';
+        return;
+    }
+
+    if (emailInput.value === ALREADY_EXIST_EMAIL) {
+        errorSpan.textContent = '이미 사용 중인 이메일입니다.';
+        return;
+    }
+
+    errorSpan.hidden = true;
+    emailInput.classList.remove('error');
+}
+emailInput.addEventListener('focusout', checkEmail);
+
+function checkPassword() {
+    const errorPSpan = passwordInput.parentElement.nextElementSibling;
+    if (!validatePassword(passwordInput.value)) {
+        errorPSpan.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+        errorPSpan.hidden = false;
+        passwordInput.classList.add('error');
+    } else {
+        errorPSpan.hidden = true;
+        passwordInput.classList.remove('error');
+    }
+}
+passwordInput.addEventListener('focusout', checkPassword);
+
+function checkPasswordConfirm() {
+    const errorVPSpan = passwordConfirmInput.parentElement.nextElementSibling;
+    errorVPSpan.hidden = false;
+    passwordConfirmInput.classList.add('error');
+
+    if (passwordInput.value !== passwordConfirmInput.value) {
+        errorVPSpan.textContent = '비밀번호가 일치하지 않아요.';
+        return;
+    }
+
+    errorVPSpan.hidden = true;
+    passwordConfirmInput.classList.remove('error');
+}
+passwordConfirmInput.addEventListener('focusout', checkPasswordConfirm);
+
+// 회원가입 폼에 대한 이벤트 리스너
+function submitForm(event) {
+    event.preventDefault();
+    checkEmail();
+    checkPassword();
+    checkPasswordConfirm();
+    if (
+        !emailInput.classList.contains('error') &&
+        !passwordInput.classList.contains('error') &&
+        !passwordConfirmInput.classList.contains('error')
+    ) {
+        window.location.href = '/folder';
+    }
+}
+form.addEventListener('submit', submitForm);

--- a/src/sign.css
+++ b/src/sign.css
@@ -150,3 +150,11 @@ header {
   padding-top: 0.2rem;
   background-color: #f5e14b;
 }
+
+.error {
+  border: 1px solid var(--red);
+}
+
+.error-message {
+  color: var(--red);
+}


### PR DESCRIPTION
## 요구사항

### 기본

- [ ] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [ ] 이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [ ] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [ ] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [ ] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [ ] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [ ] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [ ] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?
### 심화
- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항
- signup.html내 input태그 구조 변경
- 에러를 알려주는 p 태그 추가

## 스크린샷
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/33426203/b2483fae-b32d-4ea2-aa03-8a9e45754c21)


## 멘토에게
- 이번 주차 요구 사항 밖에 못 했습니다
-