### PR TITLE
[이주형] Week5

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -1,0 +1,20 @@
+export const ErrorMessage = {
+  NoInputId: "이메일 주소를 입력해 주세요.",
+  NoInputPassword: "비밀번호를 입력해 주세요.",
+  InvalidId: "올바른 이메일 주소가 아닙니다.",
+  InvalidPassword: "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.",
+  WrongId: "이메일을 확인해 주세요.",
+  WrongPassword: "비밀번호를 확인해 주세요.",
+  UnmatchedPassword: "비밀번호가 일치하지 않습니다.",
+  CantUseId: "이미 사용 중인 이메일입니다.",
+};
+
+export const isValidEmail = (email) => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+};
+
+export const isValidPassword = (password) => {
+  const passwordRegex = /^[A-Za-z0-9][A-Za-z0-9]*$/;
+  return passwordRegex.test(password);
+};

--- a/signin.html
+++ b/signin.html
@@ -30,7 +30,7 @@
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
             <input class="sign-input input-password" type="password" placeholder="비밀 번호">
-            <button class="eye-button" onclick="togglePassword()" type="button">
+            <button class="eye-button" type="button">
               <img src="/images/eye-off.png" id="eye-off">
               <img src="/images/eye-on.png" id="eye-on">
             </button>
@@ -51,6 +51,6 @@
         </div>
       </div>
     </div>
-    <script src="signin.js"></script>
+    <script type="module" src="signin.js"></script>
   </body>
 </html>

--- a/signin.js
+++ b/signin.js
@@ -1,3 +1,6 @@
+
+
+
 const myInputEmail = document.querySelector('.input-email');
 const myInputPassword = document.querySelector('.input-password');
 const errorMessageId = document.getElementById('error-message-id');

--- a/signin.js
+++ b/signin.js
@@ -1,4 +1,4 @@
-
+import * as signJs from "./sign.js";
 
 
 const myInputEmail = document.querySelector('.input-email');
@@ -9,36 +9,31 @@ const login = document.querySelector('.cta');
 const toggleButtonPw = document.querySelector('.eye-button');
 const eyeOn = document.getElementById('eye-on');
 const eyeOff = document.getElementById('eye-off');
-
-// 검색하여 email 형식이 맞는 지 확인하는 방법을 찾음.
-function isValidEmail(email) {
-  let emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email);
-}
+const addClassError = (errorClass, currentClass, errorMessage) => {
+  errorClass.style.display = 'block';
+  currentClass.classList.add('error');
+  errorClass.textContent = errorMessage;
+};
+const removeClassError = (errorMessage, currentClass) => {
+  errorMessage.style.display = 'none';
+  currentClass.classList.remove('error');
+};
 
 myInputEmail.addEventListener('focusout', function() {
   if (myInputEmail.value === '') {
-    errorMessageId.textContent = '이메일 주소를 입력해 주세요.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
-  } else if (!isValidEmail(myInputEmail.value.trim())) {
-    errorMessageId.textContent = '올바른 이메일 주소가 아닙니다.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.NoInputId);
+  } else if (!signJs.isValidEmail(myInputEmail.value)) {
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.InvalidId);
   } else {
-    errorMessageId.style.display = 'none';
-    myInputEmail.classList.remove('error');
+    removeClassError(errorMessageId, myInputEmail);
   }
 });
 
 myInputPassword.addEventListener('focusout', function() {
   if (myInputPassword.value === '') {
-    errorMessagePw.textContent = '비밀번호를 입력해 주세요.';
-    errorMessagePw.style.display = 'block';
-    myInputPassword.classList.add('error');
+    addClassError(errorMessagePw, myInputPassword, signJs.ErrorMessage.NoInputPassword);
   } else {
-    errorMessagePw.style.display = 'none';
-    myInputPassword.classList.remove('error');
+    removeClassError(errorMessagePw, myInputPassword);
   }
 });
 
@@ -48,12 +43,8 @@ login.addEventListener('click', function() {
   if (myInputEmail.value === answerEmail && myInputPassword.value == answerPassword) {
     window.location.href = '/folder';
   } else {
-    errorMessageId.textContent = '이메일을 확인해 주세요.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
-    errorMessagePw.textContent = '비밀번호를 확인해 주세요.';
-    errorMessagePw.style.display = 'block';
-    myInputPassword.classList.add('error');
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.WrongId);
+    addClassError(errorMessagePw, myInputPassword, signJs.ErrorMessage.WrongPassword);
   }
 });
 
@@ -62,8 +53,7 @@ document.querySelector('.sign-form').addEventListener('submit', function(event) 
   event.preventDefault();
 });
 
-
-function togglePassword() {
+toggleButtonPw.addEventListener('click', function() {
   if (myInputPassword.type === 'password') {
     myInputPassword.type = 'text';
     eyeOn.style.display = 'none';
@@ -73,5 +63,15 @@ function togglePassword() {
     eyeOn.style.display = 'block';
     eyeOff.style.display = 'none';
   }
-}
+});
 
+export { 
+  myInputEmail, 
+  myInputPassword, 
+  errorMessageId, 
+  errorMessagePw,
+  login, 
+  toggleButtonPw,
+  eyeOff, 
+  eyeOn,
+};

--- a/signin.js
+++ b/signin.js
@@ -6,8 +6,6 @@ const myInputPassword = document.querySelector('.input-password');
 const errorMessageId = document.getElementById('error-message-id');
 const errorMessagePw = document.getElementById('error-message-pw');
 const login = document.querySelector('.cta');
-const answerEmail = 'test@codeit.com';
-const answerPassword = 'codeit101';
 const toggleButtonPw = document.querySelector('.eye-button');
 const eyeOn = document.getElementById('eye-on');
 const eyeOff = document.getElementById('eye-off');
@@ -45,6 +43,8 @@ myInputPassword.addEventListener('focusout', function() {
 });
 
 login.addEventListener('click', function() { 
+  const answerEmail = 'test@codeit.com';
+  const answerPassword = 'codeit101';
   if (myInputEmail.value === answerEmail && myInputPassword.value == answerPassword) {
     window.location.href = '/folder';
   } else {

--- a/signin.js
+++ b/signin.js
@@ -74,4 +74,6 @@ export {
   toggleButtonPw,
   eyeOff, 
   eyeOn,
+  addClassError,
+  removeClassError,
 };

--- a/signup.html
+++ b/signup.html
@@ -55,5 +55,6 @@
         </div>
       </div>
     </div>
+    <script src="signup.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -29,8 +29,8 @@
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input input-password" type="password" placeholder="비밀 번호">
-            <button class="eye-button" onclick="togglePassword()" type="button">
+            <input class="sign-input input-password input-password-get" type="password" placeholder="비밀 번호">
+            <button class="eye-button" type="button">
               <img src="/images/eye-off.png" id="eye-off">
               <img src="/images/eye-on.png" id="eye-on">
             </button>
@@ -38,12 +38,12 @@
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input input-password" type="password" placeholder="비밀 번호">
-            <button class="eye-button" onclick="togglePassword()" type="button">
-              <img src="/images/eye-off.png" id="eye-off">
-              <img src="/images/eye-on.png" id="eye-on">
+            <input class="sign-input input-password input-password-check" type="password" placeholder="비밀 번호 확인">
+            <button class="eye-button-1" type="button">
+              <img src="/images/eye-off.png" id="eye-off-1">
+              <img src="/images/eye-on.png" id="eye-on-1">
             </button>
-            <p id="error-message-pw"></p>
+            <p id="error-message-pw-check"></p>
           </div>
         </div>
         <button class="cta" type="submit">회원가입</button>
@@ -60,6 +60,6 @@
         </div>
       </div>
     </div>
-    <script src="signup.js"></script>
+    <script type="module" src="signup.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -24,21 +24,26 @@
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" />
+            <input class="sign-input input-email" type="email" placeholder="이메일">
+            <p id="error-message-id"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="/images/eye-off.png" />
+            <input class="sign-input input-password" type="password" placeholder="비밀 번호">
+            <button class="eye-button" onclick="togglePassword()" type="button">
+              <img src="/images/eye-off.png" id="eye-off">
+              <img src="/images/eye-on.png" id="eye-on">
             </button>
+            <p id="error-message-pw"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="/images/eye-off.png" />
+            <input class="sign-input input-password" type="password" placeholder="비밀 번호">
+            <button class="eye-button" onclick="togglePassword()" type="button">
+              <img src="/images/eye-off.png" id="eye-off">
+              <img src="/images/eye-on.png" id="eye-on">
             </button>
+            <p id="error-message-pw"></p>
           </div>
         </div>
         <button class="cta" type="submit">회원가입</button>

--- a/signup.js
+++ b/signup.js
@@ -1,64 +1,81 @@
+import * as signJs from "./sign.js";
 import {
-  isValidEmail, 
-  togglePassword, 
   myInputEmail, 
   myInputPassword, 
   errorMessageId, 
   errorMessagePw,
   login, 
-  toggleButtonPW, 
+  toggleButtonPw,
   eyeOff, 
-  eyeOn 
+  eyeOn,
+  addClassError,
+  removeClassError,
 } from './signin.js';
 
-
+const getMyInputPassword = document.querySelector('.input-password-get');
+const checkMyInputPassword = document.querySelector('.input-password-check');
+const errorMessagePwCheck = document.getElementById('error-message-pw-check');
+const checkError = (input) =>  !errorMessageId.classList.contains('error');
+const eyeOnCheck = document.getElementById('eye-on-1');
+const eyeOffCheck = document.getElementById('eye-off-1');
+const toggleButtonPwCheck = document.querySelector('.eye-button-1');
 
 myInputEmail.addEventListener('focusout', function() {
-  if (myInputEmail.value === '') {
-    errorMessageId.textContent = '이메일 주소를 입력해 주세요.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
-  } else if (!isValidEmail(myInputEmail.value.trim())) {
-    errorMessageId.textContent = '올바른 이메일 주소가 아닙니다.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
-  } else {
-    errorMessageId.style.display = 'none';
-    myInputEmail.classList.remove('error');
-  }
+  const answerEmail = 'test@codeit.com';
+  if (myInputEmail.value === '') 
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.NoInputId);
+  else if (!signJs.isValidEmail(myInputEmail.value)) 
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.InvalidId);
+  else if (myInputEmail.value === answerEmail) 
+    addClassError(errorMessageId, myInputEmail, signJs.ErrorMessage.CantUseId);
+  else 
+    removeClassError(errorMessageId, myInputEmail);
 });
 
 myInputPassword.addEventListener('focusout', function() {
-  if (myInputPassword.value === '') {
-    errorMessagePw.textContent = '비밀번호를 입력해 주세요.';
-    errorMessagePw.style.display = 'block';
-    myInputPassword.classList.add('error');
-  } else {
-    errorMessagePw.style.display = 'none';
-    myInputPassword.classList.remove('error');
-  }
+  if (myInputPassword.value === '') 
+    addClassError(errorMessagePw, myInputPassword, signJs.ErrorMessage.NoInputPassword);
+  else if(!signJs.isValidPassword(myInputPassword.value))
+    addClassError(errorMessagePw, myInputPassword, signJs.ErrorMessage.InvalidPassword);
+  else
+    removeClassError(errorMessagePw, myInputPassword);
 });
 
-login.addEventListener('click', function() { 
-  const answerEmail = 'test@codeit.com';
-  const answerPassword = 'codeit101';
-  if (myInputEmail.value === answerEmail && myInputPassword.value == answerPassword) {
+login.addEventListener('click', function() {
+  if (getMyInputPassword.value !== checkMyInputPassword.value) 
+    addClassError(errorMessagePwCheck, checkMyInputPassword, signJs.ErrorMessage.UnmatchedPassword);
+  else if (checkError(errorMessageId) && checkError(errorMessagePw) && checkError(errorMessagePwCheck) && myInputPassword.value !== '')
     window.location.href = '/folder';
-  } else {
-    errorMessageId.textContent = '이메일을 확인해 주세요.';
-    errorMessageId.style.display = 'block';
-    myInputEmail.classList.add('error');
-    errorMessagePw.textContent = '비밀번호를 확인해 주세요.';
-    errorMessagePw.style.display = 'block';
-    myInputPassword.classList.add('error');
-  }
-});
+})
 
 // 검색하여 form 제출 시 페이지 새로고침되지 않게 함.
 document.querySelector('.sign-form').addEventListener('submit', function(event) {
   event.preventDefault();
 });
 
+toggleButtonPw.addEventListener('click', function() {
+  if (getMyInputPassword.type === 'password') {
+    getMyInputPassword.type = 'text';
+    eyeOn.style.display = 'none';
+    eyeOff.style.display = 'block';
+  } else {
+    getMyInputPassword.type = 'password';
+    eyeOn.style.display = 'block';
+    eyeOff.style.display = 'none';
+  }
+});
+
+toggleButtonPwCheck.addEventListener('click', function() {
+  if (checkMyInputPassword.type === 'password') {
+    checkMyInputPassword.type = 'text';
+    eyeOnCheck.style.display = 'none';
+    eyeOffCheck.style.display = 'block';
+  } else {
+    checkMyInputPassword.type = 'password';
+    eyeOnCheck.style.display = 'block';
+    eyeOffCheck.style.display = 'none';
+  }
+});
 
 
 

--- a/signup.js
+++ b/signup.js
@@ -1,0 +1,64 @@
+import {
+  isValidEmail, 
+  togglePassword, 
+  myInputEmail, 
+  myInputPassword, 
+  errorMessageId, 
+  errorMessagePw,
+  login, 
+  toggleButtonPW, 
+  eyeOff, 
+  eyeOn 
+} from './signin.js';
+
+
+
+myInputEmail.addEventListener('focusout', function() {
+  if (myInputEmail.value === '') {
+    errorMessageId.textContent = '이메일 주소를 입력해 주세요.';
+    errorMessageId.style.display = 'block';
+    myInputEmail.classList.add('error');
+  } else if (!isValidEmail(myInputEmail.value.trim())) {
+    errorMessageId.textContent = '올바른 이메일 주소가 아닙니다.';
+    errorMessageId.style.display = 'block';
+    myInputEmail.classList.add('error');
+  } else {
+    errorMessageId.style.display = 'none';
+    myInputEmail.classList.remove('error');
+  }
+});
+
+myInputPassword.addEventListener('focusout', function() {
+  if (myInputPassword.value === '') {
+    errorMessagePw.textContent = '비밀번호를 입력해 주세요.';
+    errorMessagePw.style.display = 'block';
+    myInputPassword.classList.add('error');
+  } else {
+    errorMessagePw.style.display = 'none';
+    myInputPassword.classList.remove('error');
+  }
+});
+
+login.addEventListener('click', function() { 
+  const answerEmail = 'test@codeit.com';
+  const answerPassword = 'codeit101';
+  if (myInputEmail.value === answerEmail && myInputPassword.value == answerPassword) {
+    window.location.href = '/folder';
+  } else {
+    errorMessageId.textContent = '이메일을 확인해 주세요.';
+    errorMessageId.style.display = 'block';
+    myInputEmail.classList.add('error');
+    errorMessagePw.textContent = '비밀번호를 확인해 주세요.';
+    errorMessagePw.style.display = 'block';
+    myInputPassword.classList.add('error');
+  }
+});
+
+// 검색하여 form 제출 시 페이지 새로고침되지 않게 함.
+document.querySelector('.sign-form').addEventListener('submit', function(event) {
+  event.preventDefault();
+});
+
+
+
+

--- a/src/sign.css
+++ b/src/sign.css
@@ -100,7 +100,7 @@ header {
 
 .eye-button {
   position: absolute;
-  bottom: 2.2rem;
+  top: 5.1rem;
   right: 1.5rem;
   width: 1.6rem;
   height: 1.6rem;

--- a/src/sign.css
+++ b/src/sign.css
@@ -93,12 +93,12 @@ header {
   border-color: var(--red);
 }
 
-#error-message-pw, #error-message-id {
+#error-message-pw, #error-message-id, #error-message-pw-check {
   color: var(--red);
   display: none;
 }
 
-.eye-button {
+.eye-button, .eye-button-1 {
   position: absolute;
   top: 5.1rem;
   right: 1.5rem;
@@ -106,9 +106,10 @@ header {
   height: 1.6rem;
 }
 
-#eye-on {
+#eye-on, #eye-on-1 {
   display: none;
 }
+
 
 .cta {
   display: flex;


### PR DESCRIPTION
## 요구사항

### 기본


- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [ ] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?



### 심화


- [ ] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 PR 적용했습니다.
- sign.js로 모듈화 진행했습니다.

## 스크린샷
[https://cgw-codeit.netlify.app/](url)
## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
