### PR TITLE
[최수민] Week5

### DIFF
--- a/signin.html
+++ b/signin.html
@@ -24,28 +24,28 @@
       </p>
     </header>
     <div class="sign-box">
-      <form class="sign-form">
+      <form class="sign-form" id="signForm">
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
             <div class="sign-input-box-include-error">
-              <input class="sign-input" id="email" />
+              <input class="sign-input" id="emailInput" />
               <p id="error-message-email" class="display-none"></p>
             </div>
           </div>
           <div class="sign-input-box">
             <label class="sign-input-label">비밀번호</label>
             <div class="sign-input-box-include-error sign-password">
-              <input class="sign-input" type="password" id="password" />
+              <input class="sign-input" type="password" id="passwordInput" />
               <p id="error-message-password" class="display-none"></p>
               <button class="eye-button" type="button">
-                <img src="./images/eye-off.svg" />
-                <img src="./images/eye-on.svg" class="display-none" />
+                <img src="./images/eye-off.svg" id="offEye" />
+                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
               </button>
             </div>
           </div>
         </div>
-        <button class="cta" type="submit">로그인</button>
+        <button class="cta" type="submit" id="loginBtn">로그인</button>
       </form>
       <div class="sns-box">
         <span class="sns-text">소셜 로그인</span>

--- a/signin.html
+++ b/signin.html
@@ -38,9 +38,9 @@
             <div class="sign-input-box-include-error sign-password">
               <input class="sign-input" type="password" id="passwordInput" />
               <p id="error-message-password" class="display-none"></p>
-              <button class="eye-button" type="button" id="eyeBtn">
-                <img src="./images/eye-off.svg" id="offEye" />
-                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
+              <button class="eye-button" type="button" id="passwordEyeBtn">
+                <img src="./images/eye-off.svg" id="passwordEyeOff" />
+                <img src="./images/eye-on.svg" id="passwordEyeOn" class="display-none" />
               </button>
             </div>
           </div>

--- a/signin.html
+++ b/signin.html
@@ -38,14 +38,14 @@
             <div class="sign-input-box-include-error sign-password">
               <input class="sign-input" type="password" id="passwordInput" />
               <p id="error-message-password" class="display-none"></p>
-              <button class="eye-button" type="button">
+              <button class="eye-button" type="button" id="eyeBtn">
                 <img src="./images/eye-off.svg" id="offEye" />
                 <img src="./images/eye-on.svg" id="onEye" class="display-none" />
               </button>
             </div>
           </div>
         </div>
-        <button class="cta" type="submit" id="loginBtn">로그인</button>
+        <button class="cta" type="submit" id="submitBtn">로그인</button>
       </form>
       <div class="sns-box">
         <span class="sns-text">소셜 로그인</span>
@@ -59,6 +59,6 @@
         </div>
       </div>
     </div>
-    <script src="./src/JS/sign.js"></script>
+    <script type="module" src="./src/JS/signin.js"></script>
   </body>
-</html>
+  </html>

--- a/signup.html
+++ b/signup.html
@@ -38,20 +38,20 @@
             <div class="sign-input-box-include-error sign-password">
               <input class="sign-input" type="password" id="passwordInput" />
               <p id="error-message-password" class="display-none"></p>
-              <button class="eye-button" type="button" id="eyeBtn">
-                <img src="./images/eye-off.svg" id="offEye" />
-                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
+              <button class="eye-button" type="button" id="passwordEyeBtn">
+                <img src="./images/eye-off.svg" id="passwordEyeOff" />
+                <img src="./images/eye-on.svg" id="passwordEyeOn" class="display-none" />
               </button>
             </div>
           </div>
           <div class="sign-input-box">
             <label class="sign-input-label">비밀번호 확인</label>
             <div class="sign-input-box-include-error sign-password">
-              <input class="sign-input" type="password" id="passwordInput"/>
-              <p id="error-message-password" class="display-none"></p>
-              <button class="eye-button" type="button" id="eyeBtn">
-                <img src="./images/eye-off.svg" id="offEye" />
-                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
+              <input class="sign-input" type="password" id="passwordCheckInput"/>
+              <p id="error-message-password-check" class="display-none"></p>
+              <button class="eye-button" type="button" id="passwordCheckEyeBtn">
+                <img src="./images/eye-off.svg" id="passwordCheckEyeOff" />
+                <img src="./images/eye-on.svg" id="passwordCheckEyeOn" class="display-none" />
               </button>
             </div>
           </div>

--- a/signup.html
+++ b/signup.html
@@ -24,28 +24,39 @@
       </p>
     </header>
     <div class="sign-box">
-      <form class="sign-form">
+      <form class="sign-form" id="signForm">
         <div class="sign-inputs">
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
-            <input class="sign-input" />
+            <div class="sign-input-box-include-error">
+              <input class="sign-input" id="emailInput" />
+              <p id="error-message-email" class="display-none"></p>
+            </div>
           </div>
-          <div class="sign-input-box sign-password">
+          <div class="sign-input-box">
             <label class="sign-input-label">비밀번호</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="./images/eye-off.svg" />
-            </button>
+            <div class="sign-input-box-include-error sign-password">
+              <input class="sign-input" type="password" id="passwordInput" />
+              <p id="error-message-password" class="display-none"></p>
+              <button class="eye-button" type="button" id="eyeBtn">
+                <img src="./images/eye-off.svg" id="offEye" />
+                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
+              </button>
+            </div>
           </div>
-          <div class="sign-input-box sign-password">
+          <div class="sign-input-box">
             <label class="sign-input-label">비밀번호 확인</label>
-            <input class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="./images/eye-off.svg" />
-            </button>
+            <div class="sign-input-box-include-error sign-password">
+              <input class="sign-input" type="password" id="passwordInput"/>
+              <p id="error-message-password" class="display-none"></p>
+              <button class="eye-button" type="button" id="eyeBtn">
+                <img src="./images/eye-off.svg" id="offEye" />
+                <img src="./images/eye-on.svg" id="onEye" class="display-none" />
+              </button>
+            </div>
           </div>
         </div>
-        <button class="cta" type="submit">회원가입</button>
+        <button class="cta" type="submit" id="submitBtn">회원가입</button>
       </form>
       <div class="sns-box">
         <span class="sns-text">다른 방식으로 가입하기</span>
@@ -59,5 +70,6 @@
         </div>
       </div>
     </div>
+    <script type="module" src="./src/JS/signup.js"></script>
   </body>
 </html>

--- a/src/CSS/sign.css
+++ b/src/CSS/sign.css
@@ -113,13 +113,9 @@ header {
   border: 0.1rem solid var(--red);
 }
 
-#error-message-email {
-  color: var(--red);
-  font-size: 1.4rem;
-  font-weight: 400;
-}
-
-#error-message-password {
+#error-message-email,
+#error-message-password,
+#error-message-password-check {
   color: var(--red);
   font-size: 1.4rem;
   font-weight: 400;

--- a/src/JS/sign.js
+++ b/src/JS/sign.js
@@ -1,114 +1,101 @@
-const form = document.querySelector('.sign-form');
-const inputs = document.querySelector('.sign-inputs');
+const signForm = document.querySelector('#signForm');
 const errorMessageEmail = document.querySelector('#error-message-email');
 const errorMessagePassword = document.querySelector('#error-message-password');
-const email = document.querySelector('#email');
-const password = document.querySelector('#password');
+const emailInput = document.querySelector('#emailInput');
+const passwordInput = document.querySelector('#passwordInput');
+const loginBtn = document.querySelector('#loginBtn');
+const eyeBtn = document.querySelector('.eye-button');
+const eyeOff = document.querySelector('#offEye');
+const eyeOn = document.querySelector('#onEye');
 
-function testEmail(email_address){     
+function checkValidationEmail(email_address){     
 	email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
 	if(!email_regex.test(email_address)){ 
 		return false; 
 	} else {
 		return true;
 	};
-};
+}; // 이메일이 정규식인지 확인해서 불린값 리턴함
 
-function validateEmail(e){
-  if(!testEmail(e.target.value) && e.target.value !== ''){
-    e.target.classList.add('sign-input-error');
-    errorMessageEmail.innerHTML = "올바른 이메일 주소가 아닙니다";
-    errorMessageEmail.classList.remove('display-none');
-  } else {
-    e.target.classList.remove('sign-input-error');
-    errorMessageEmail.classList.add('display-none');
-  };
-};
+function errorMsgAdd(input, msgType, errText){
+  input.classList.add('sign-input-error');
+  msgType.innerHTML = errText;
+  msgType.classList.remove('display-none');
+}; // 에러 메세지 출력
 
-function typeEmail(e){
-  if (email.value === ""){
-    email.classList.add('sign-input-error');
-    errorMessageEmail.innerHTML = "이메일을 입력해 주세요";
-    errorMessageEmail.classList.remove('display-none');
-  };
-};
+function errorMsgRemove(input, msgType){
+  input.classList.remove('sign-input-error');
+  msgType.classList.add('display-none');
+}; // 에러 메세지 지우기
 
-inputs.firstElementChild.addEventListener('focusout', validateEmail);
-inputs.firstElementChild.addEventListener('focusout', typeEmail);
+function checkEmail(){
+  if (emailInput.value === ""){
+        errorMsgAdd(emailInput, errorMessageEmail, "이메일을 입력해 주세요");
+        return false;
+      } else if (!checkValidationEmail(emailInput.value)){
+        errorMsgAdd(emailInput, errorMessageEmail, "올바른 이메일 주소가 아닙니다");
+        return false;
+      } else {
+        errorMsgRemove(emailInput, errorMessageEmail);
+        return true;
+      };
+}; // 이메일 유효성 체크
 
-function typePassword(e){
-  if (password.value === ""){
-    password.classList.add('sign-input-error');
-    errorMessagePassword.innerHTML = "비밀번호를 입력해 주세요";
-    errorMessagePassword.classList.remove('display-none');
-  } else {
-    password.classList.remove('sign-input-error');
-    errorMessagePassword.classList.add('display-none');
-  }
-};
-
-inputs.lastElementChild.addEventListener('focusout', typePassword);
-
-function loginEmailCheck(){
-  if (email.value === "test@codeit.kr"){
-    return true;
-  } else {
-    email.classList.add('sign-input-error');
-    errorMessageEmail.innerHTML = "이메일을 확인해 주세요";
-    errorMessageEmail.classList.remove('display-none');
+function checkPassword(){
+  if (passwordInput.value === ""){
+    errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 입력해 주세요");
     return false;
-  }
-};
-
-function loginPasswordCheck(){
-  if (password.value === "codeit101"){
-    return true;
   } else {
-    password.classList.add('sign-input-error');
-    errorMessagePassword.innerHTML = "비밀번호를 확인해 주세요";
-    errorMessagePassword.classList.remove('display-none');
-    return false;
+    errorMsgRemove(passwordInput, errorMessagePassword);
+    return true;
   }
-};
+}; // 비밀번호 유효성 체크
 
-function loginCheck(e){
+function loginCheck(){
+  if(checkEmail() && checkPassword()){ // 먼저 이메일과 비밀번호의 유효성 확인
+    if(emailInput.value === 'test@codeit.com' && passwordInput.value === "codeit101"){
+      return true;
+    } else if (emailInput.value !== 'test@codeit.com' && passwordInput.value !== "codeit101"){
+      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
+      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
+      return false;
+    } else if (emailInput.value !== 'test@codeit.com'){
+      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
+      return false;
+    } else if (passwordInput.value !== "codeit101"){
+      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
+      return false;
+    };
+  };
+}; // 허락된 계정인지 확인
+
+function tryLogin(e){
   e.preventDefault();
-  if (loginEmailCheck() && loginPasswordCheck()){
-    let link = 'folder.html';
+  if(loginCheck()){
+    let link = '/folder.html';
     window.location.href = link;
   };
-};
-
-form.lastElementChild.addEventListener('click', loginCheck);
-document.addEventListener('keypress', function(e){
-  if (e.key === 'enter'){
-    loginCheck(e);
-  }
-});
-
-const eyeBtn = document.querySelector('.eye-button');
-
-function switchType(){
-  if(password.getAttribute('type') === 'password'){
-    password.setAttribute('type', 'text');
-  } else {
-    password.setAttribute('type', 'password');
-  }
-};
-
-function switchEye(){
-  if(password.getAttribute('type') === 'password'){
-    eyeBtn.lastElementChild.setAttribute('class', 'display-none');
-    eyeBtn.firstElementChild.removeAttribute('class');
-  } else {
-    eyeBtn.firstElementChild.setAttribute('class', 'display-none');
-    eyeBtn.lastElementChild.removeAttribute('class');
-  }
-};
+}; // 로그인 시도
 
 function toggleEyeBtn(){
-  switchType();
-  switchEye();
-};
+  if(passwordInput.getAttribute('type') === 'password'){
+    passwordInput.setAttribute('type', 'text'); // 비밀번호 보이기
+    eyeOff.classList.add('display-none'); // 눈 아이콘 변경
+    eyeOn.classList.remove('display-none');
+  } else {
+    passwordInput.setAttribute('type', 'password'); // 비밀번호 가리기
+    eyeOn.classList.add('display-none'); // 눈 아이콘 변경
+    eyeOff.classList.remove('display-none');
+  }
+}; // 비밀번호 보이기/가리기
 
+// 이벤트 관리
+emailInput.addEventListener('focusout', checkEmail);
+passwordInput.addEventListener('focusout', checkPassword);
+loginBtn.addEventListener('click', tryLogin);
+signForm.addEventListener('keydown', function(event){
+  if (event.key === 'Enter'){
+    tryLogin(e);
+  };
+});
 eyeBtn.addEventListener('click', toggleEyeBtn);

--- a/src/JS/sign.js
+++ b/src/JS/sign.js
@@ -5,9 +5,9 @@ const errorMessagePassword = document.querySelector('#error-message-password');
 const emailInput = document.querySelector('#emailInput');
 const passwordInput = document.querySelector('#passwordInput');
 const submitBtn = document.querySelector('#submitBtn');
-const eyeBtn = document.querySelector('#eyeBtn');
-const eyeOff = document.querySelector('#offEye');
-const eyeOn = document.querySelector('#onEye');
+const passwordEyeBtn = document.querySelector('#passwordEyeBtn');
+const passwordEyeOff = document.querySelector('#passwordEyeOff');
+const passwordEyeOn = document.querySelector('#passwordEyeOn');
 
 function checkValidationEmail(email_address){     
 	let email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
@@ -29,16 +29,16 @@ function errorMsgRemove(input, msgType){
   msgType.classList.add('display-none');
 }; // 에러 메세지 지우기
 
-function toggleEyeBtn(){
+function togglePasswordEyeBtn(){
   if(passwordInput.getAttribute('type') === 'password'){
     passwordInput.setAttribute('type', 'text'); // 비밀번호 보이기
-    eyeOff.classList.add('display-none'); // 눈 아이콘 변경
-    eyeOn.classList.remove('display-none');
+    passwordEyeOff.classList.add('display-none'); // 눈 아이콘 변경
+    passwordEyeOn.classList.remove('display-none');
   } else {
     passwordInput.setAttribute('type', 'password'); // 비밀번호 가리기
-    eyeOn.classList.add('display-none'); // 눈 아이콘 변경
-    eyeOff.classList.remove('display-none');
+    passwordEyeOn.classList.add('display-none'); // 눈 아이콘 변경
+    passwordEyeOff.classList.remove('display-none');
   }
 }; // 비밀번호 보이기/가리기
 
-export { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn };
+export { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, passwordEyeBtn, passwordEyeOff, passwordEyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, togglePasswordEyeBtn };

--- a/src/JS/sign.js
+++ b/src/JS/sign.js
@@ -1,15 +1,16 @@
+// sign 공통변수
 const signForm = document.querySelector('#signForm');
 const errorMessageEmail = document.querySelector('#error-message-email');
 const errorMessagePassword = document.querySelector('#error-message-password');
 const emailInput = document.querySelector('#emailInput');
 const passwordInput = document.querySelector('#passwordInput');
-const loginBtn = document.querySelector('#loginBtn');
-const eyeBtn = document.querySelector('.eye-button');
+const submitBtn = document.querySelector('#submitBtn');
+const eyeBtn = document.querySelector('#eyeBtn');
 const eyeOff = document.querySelector('#offEye');
 const eyeOn = document.querySelector('#onEye');
 
 function checkValidationEmail(email_address){     
-	email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+	let email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
 	if(!email_regex.test(email_address)){ 
 		return false; 
 	} else {
@@ -51,32 +52,6 @@ function checkPassword(){
   }
 }; // 비밀번호 유효성 체크
 
-function loginCheck(){
-  if(checkEmail() && checkPassword()){ // 먼저 이메일과 비밀번호의 유효성 확인
-    if(emailInput.value === 'test@codeit.com' && passwordInput.value === "codeit101"){
-      return true;
-    } else if (emailInput.value !== 'test@codeit.com' && passwordInput.value !== "codeit101"){
-      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
-      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
-      return false;
-    } else if (emailInput.value !== 'test@codeit.com'){
-      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
-      return false;
-    } else if (passwordInput.value !== "codeit101"){
-      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
-      return false;
-    };
-  };
-}; // 허락된 계정인지 확인
-
-function tryLogin(e){
-  e.preventDefault();
-  if(loginCheck()){
-    let link = '/folder.html';
-    window.location.href = link;
-  };
-}; // 로그인 시도
-
 function toggleEyeBtn(){
   if(passwordInput.getAttribute('type') === 'password'){
     passwordInput.setAttribute('type', 'text'); // 비밀번호 보이기
@@ -89,13 +64,4 @@ function toggleEyeBtn(){
   }
 }; // 비밀번호 보이기/가리기
 
-// 이벤트 관리
-emailInput.addEventListener('focusout', checkEmail);
-passwordInput.addEventListener('focusout', checkPassword);
-loginBtn.addEventListener('click', tryLogin);
-signForm.addEventListener('keydown', function(event){
-  if (event.key === 'Enter'){
-    tryLogin(e);
-  };
-});
-eyeBtn.addEventListener('click', toggleEyeBtn);
+export { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, checkEmail, checkPassword, toggleEyeBtn };

--- a/src/JS/sign.js
+++ b/src/JS/sign.js
@@ -29,29 +29,6 @@ function errorMsgRemove(input, msgType){
   msgType.classList.add('display-none');
 }; // 에러 메세지 지우기
 
-function checkEmail(){
-  if (emailInput.value === ""){
-        errorMsgAdd(emailInput, errorMessageEmail, "이메일을 입력해 주세요");
-        return false;
-      } else if (!checkValidationEmail(emailInput.value)){
-        errorMsgAdd(emailInput, errorMessageEmail, "올바른 이메일 주소가 아닙니다");
-        return false;
-      } else {
-        errorMsgRemove(emailInput, errorMessageEmail);
-        return true;
-      };
-}; // 이메일 유효성 체크
-
-function checkPassword(){
-  if (passwordInput.value === ""){
-    errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 입력해 주세요");
-    return false;
-  } else {
-    errorMsgRemove(passwordInput, errorMessagePassword);
-    return true;
-  }
-}; // 비밀번호 유효성 체크
-
 function toggleEyeBtn(){
   if(passwordInput.getAttribute('type') === 'password'){
     passwordInput.setAttribute('type', 'text'); // 비밀번호 보이기
@@ -64,4 +41,4 @@ function toggleEyeBtn(){
   }
 }; // 비밀번호 보이기/가리기
 
-export { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, checkEmail, checkPassword, toggleEyeBtn };
+export { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn };

--- a/src/JS/signin.js
+++ b/src/JS/signin.js
@@ -1,4 +1,4 @@
-import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as loginBtn, eyeBtn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn } from './sign.js';
+import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as loginBtn, passwordEyeBtn, checkValidationEmail, errorMsgAdd, errorMsgRemove, togglePasswordEyeBtn } from './sign.js';
 
 function checkEmail(){
   if (emailInput.value === ""){
@@ -58,4 +58,4 @@ signForm.addEventListener('keydown', function(event){
     tryLogin(e);
   };
 });
-eyeBtn.addEventListener('click', toggleEyeBtn);
+passwordEyeBtn.addEventListener('click', togglePasswordEyeBtn);

--- a/src/JS/signin.js
+++ b/src/JS/signin.js
@@ -55,7 +55,7 @@ passwordInput.addEventListener('focusout', checkPassword);
 loginBtn.addEventListener('click', tryLogin);
 signForm.addEventListener('keydown', function(event){
   if (event.key === 'Enter'){
-    tryLogin(e);
+    tryLogin(event);
   };
 });
 passwordEyeBtn.addEventListener('click', togglePasswordEyeBtn);

--- a/src/JS/signin.js
+++ b/src/JS/signin.js
@@ -1,4 +1,27 @@
-import {signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as loginBtn, eyeBtn, errorMsgAdd, checkEmail, checkPassword, toggleEyeBtn} from './sign.js';
+import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as loginBtn, eyeBtn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn } from './sign.js';
+
+function checkEmail(){
+  if (emailInput.value === ""){
+        errorMsgAdd(emailInput, errorMessageEmail, "이메일을 입력해 주세요");
+        return false;
+      } else if (!checkValidationEmail(emailInput.value)){
+        errorMsgAdd(emailInput, errorMessageEmail, "올바른 이메일 주소가 아닙니다");
+        return false;
+      } else {
+        errorMsgRemove(emailInput, errorMessageEmail);
+        return true;
+      };
+}; // 이메일 유효성 체크
+
+function checkPassword(){
+  if (passwordInput.value === ""){
+    errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 입력해 주세요");
+    return false;
+  } else {
+    errorMsgRemove(passwordInput, errorMessagePassword);
+    return true;
+  }
+}; // 비밀번호 유효성 체크
 
 function loginCheck(){
   if(checkEmail() && checkPassword()){ // 먼저 이메일과 비밀번호의 유효성 확인

--- a/src/JS/signin.js
+++ b/src/JS/signin.js
@@ -1,0 +1,38 @@
+import {signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as loginBtn, eyeBtn, errorMsgAdd, checkEmail, checkPassword, toggleEyeBtn} from './sign.js';
+
+function loginCheck(){
+  if(checkEmail() && checkPassword()){ // 먼저 이메일과 비밀번호의 유효성 확인
+    if(emailInput.value === 'test@codeit.com' && passwordInput.value === "codeit101"){
+      return true;
+    } else if (emailInput.value !== 'test@codeit.com' && passwordInput.value !== "codeit101"){
+      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
+      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
+      return false;
+    } else if (emailInput.value !== 'test@codeit.com'){
+      errorMsgAdd(emailInput, errorMessageEmail, '이메일을 확인해 주세요');
+      return false;
+    } else if (passwordInput.value !== "codeit101"){
+      errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 확인해 주세요");
+      return false;
+    };
+  };
+}; // 허락된 계정인지 확인
+
+function tryLogin(e){
+  e.preventDefault();
+  if(loginCheck()){
+    let link = '/folder.html';
+    window.location.href = link;
+  };
+}; // 로그인 시도
+
+// 이벤트 관리
+emailInput.addEventListener('focusout', checkEmail);
+passwordInput.addEventListener('focusout', checkPassword);
+loginBtn.addEventListener('click', tryLogin);
+signForm.addEventListener('keydown', function(event){
+  if (event.key === 'Enter'){
+    tryLogin(e);
+  };
+});
+eyeBtn.addEventListener('click', toggleEyeBtn);

--- a/src/JS/signup.js
+++ b/src/JS/signup.js
@@ -1,3 +1,20 @@
-import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, checkEmail, checkPassword, toggleEyeBtn } from './sign.js';
+import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as signUpBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn } from './sign.js';
 
+function checkEmail(){
+  if (emailInput.value === ""){
+    errorMsgAdd(emailInput, errorMessageEmail, "이메일을 입력해 주세요");
+    return false;
+  } else if (!checkValidationEmail(emailInput.value)){
+    errorMsgAdd(emailInput, errorMessageEmail, "올바른 이메일 주소가 아닙니다");
+    return false;
+  } else if (emailInput.value === 'test@codeit.com'){
+    errorMsgAdd(emailInput, errorMessageEmail, "이미 사용 중인 이메일입니다");
+    return false;
+  } else {
+    errorMsgRemove(emailInput, errorMessageEmail);
+    return true;
+  };
+} // 이메일 유효성 및 중복 체크
+
+// 이벤트 관리
 emailInput.addEventListener('focusout', checkEmail);

--- a/src/JS/signup.js
+++ b/src/JS/signup.js
@@ -1,0 +1,3 @@
+import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, checkEmail, checkPassword, toggleEyeBtn } from './sign.js';
+
+emailInput.addEventListener('focusout', checkEmail);

--- a/src/JS/signup.js
+++ b/src/JS/signup.js
@@ -1,4 +1,11 @@
-import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as signUpBtn, eyeBtn, eyeOff, eyeOn, checkValidationEmail, errorMsgAdd, errorMsgRemove, toggleEyeBtn } from './sign.js';
+import { signForm, errorMessageEmail, errorMessagePassword, emailInput, passwordInput, submitBtn as signUpBtn, passwordEyeBtn, checkValidationEmail, errorMsgAdd, errorMsgRemove, togglePasswordEyeBtn } from './sign.js';
+
+// 회원가입에서 필요한 비밀번호 확인용 변수
+const errorMessagePasswordCheck = document.querySelector('#error-message-password-check');
+const passwordCheckInput = document.querySelector('#passwordCheckInput');
+const passwordCheckEyeBtn = document.querySelector('#passwordCheckEyeBtn');
+const passwordCheckEyeOff = document.querySelector('#passwordCheckEyeOff');
+const passwordCheckEyeOn = document.querySelector('#passwordCheckEyeOn');
 
 function checkEmail(){
   if (emailInput.value === ""){
@@ -14,7 +21,75 @@ function checkEmail(){
     errorMsgRemove(emailInput, errorMessageEmail);
     return true;
   };
-} // 이메일 유효성 및 중복 체크
+}; // 이메일 유효성 및 중복 체크
+
+function checkValidationpassword(password_value){     
+	let password_reg = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
+	if(!password_reg.test(password_value)){ 
+		return false; 
+	} else {
+		return true;
+	};
+ }; // 비밀번호 정규식 검사 함수
+
+function checkPassword(){
+  if (passwordInput.value === ""){
+    errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호를 입력해 주세요");
+    return false;
+  } else if (!checkValidationpassword(passwordInput.value)){
+    errorMsgAdd(passwordInput, errorMessagePassword, "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요");
+    return false;
+  } else {
+    errorMsgRemove(passwordInput, errorMessagePassword);
+    return true;
+  };
+}; // 비밀번호 공란 검사 및 유효성 검사
+
+function checkPasswordCheck(){
+  if (passwordCheckInput.value === ""){
+    errorMsgAdd(passwordCheckInput, errorMessagePasswordCheck, "비밀번호를 입력해 주세요");
+    return false;
+  } else if (!checkValidationpassword(passwordCheckInput.value)){
+    errorMsgAdd(passwordCheckInput, errorMessagePasswordCheck, "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요");
+    return false;
+  } else if(passwordCheckInput.value !== passwordInput.value){
+    errorMsgAdd(passwordCheckInput, errorMessagePasswordCheck, "비밀번호가 일치하지 않아요");
+    return false;
+  } else {
+    errorMsgRemove(passwordCheckInput, errorMessagePasswordCheck);
+    return true;
+  };
+}; // 비밀번호 확인의 공란 검사 및 유효성 검사 및 일치 여부 확인
+
+function trySignUp(e){
+  e.preventDefault();
+  if(checkEmail() && checkPassword() && checkPasswordCheck()){
+    let link = '/folder.html';
+    window.location.href = link;
+  };
+}; // 회원가입 시도
+
+function togglePasswordCheckEyeBtn(){
+  if(passwordCheckInput.getAttribute('type') === 'password'){
+    passwordCheckInput.setAttribute('type', 'text'); // 비밀번호 보이기
+    passwordCheckEyeOff.classList.add('display-none'); // 눈 아이콘 변경
+    passwordCheckEyeOn.classList.remove('display-none');
+  } else {
+    passwordCheckInput.setAttribute('type', 'password'); // 비밀번호 가리기
+    passwordCheckEyeOn.classList.add('display-none'); // 눈 아이콘 변경
+    passwordCheckEyeOff.classList.remove('display-none');
+  }
+}; // 비밀번호 확인 보이기/가리기
 
 // 이벤트 관리
 emailInput.addEventListener('focusout', checkEmail);
+passwordInput.addEventListener('focusout', checkPassword);
+passwordCheckInput.addEventListener('focusout', checkPasswordCheck);
+signUpBtn.addEventListener('click', trySignUp);
+signForm.addEventListener('keydown', function(event){
+  if (event.key === 'Enter'){
+    trySignUp(event);
+  };
+});
+passwordEyeBtn.addEventListener('click', togglePasswordEyeBtn);
+passwordCheckEyeBtn.addEventListener('click', togglePasswordCheckEyeBtn);


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 4주차 멘토링 내용 반영해서 리펙토링 했습니다.
- 공통의 기능은 최대한 모듈화 하였습니다.
- 회원가입 페이지의 유효성 검사 기능 추가하였습니다.

## 멘토에게

- 중복되는 작은 기능은 공통의 파일에서 관리할 수 있도록 만들었습니다. 혹시 부족한점 없는지 확인 부탁드립니다.
- 공통의 작은 기능은 공통 sign.js에 넣고, 로직을 담당하는 함수는 각각 필요한 파일에 작성하였습니다.
- signin, signup 모두 확인 부탁드립니다!
- 깔끔하게 구성하려다보니 생각보다 조금 늦었습니다. 죄송합니다!
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
