### PR TITLE
[백승아] week5

### DIFF
--- a/script/constants.js
+++ b/script/constants.js
@@ -1,5 +1,7 @@
 export const EMAIL_REGEX = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
 
+export const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
+
 export const VALID_USER = {
   email: 'test@codeit.com',
   password: 'codeit101',

--- a/script/sign.js
+++ b/script/sign.js
@@ -5,24 +5,29 @@ import {
   displayError,
   clearError,
   handlePasswordInputFocusOut,
+  handlePasswordCheckInputFocusOut,
   handleEmailInputFocusIn,
   togglePasswordVisibility,
 } from './utils.js';
 
+import { VALID_USER } from './constants.js';
+
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
-
+  const passwordcheckInput = document.getElementById('passwordcheck');
   const signInButton = document.getElementById('cta');
   const watchPassword = document.getElementById('eye-button');
 
   // 에러 메시지 요소들 생성 및 초기화
   const emailErrorMessage = createErrorMessage('email-error', '');
   const passwordErrorMessage = createErrorMessage('password-error', '');
+  const passwordCheckErrorMessage = createErrorMessage('password-check-error', ''); // 추가: 비밀번호 확인 에러 메시지
 
   // 이메일, 비밀번호 입력란 뒤에 에러 메시지 요소 추가
   emailInput.after(emailErrorMessage);
   passwordInput.after(passwordErrorMessage);
+  passwordcheckInput.after(passwordCheckErrorMessage); // 추가: 비밀번호 확인 에러 메시지
 
   // 이메일 입력란 focusin 이벤트 핸들러
   emailInput.addEventListener('focusin', function () {
@@ -32,6 +37,10 @@ document.addEventListener('DOMContentLoaded', function () {
   // 이메일 입력란 focusout 이벤트 핸들러
   emailInput.addEventListener('focusout', function () {
     handleEmailInputFocusIn(emailInput, emailErrorMessage);
+    // 추가: 이미 사용 중인 이메일 여부 검사
+    if (emailInput.value.trim() === VALID_USER.email) {
+      displayError(emailInput, emailErrorMessage, '이미 사용 중인 이메일입니다.');
+    }
   });
 
   // 비밀번호 입력란 focusout 이벤트 핸들러
@@ -39,11 +48,17 @@ document.addEventListener('DOMContentLoaded', function () {
     handlePasswordInputFocusOut(passwordInput, passwordErrorMessage);
   });
 
+  // 비밀번호 확인 입력란 focusout 이벤트 핸들러
+  passwordcheckInput.addEventListener('focusout', function () {
+    handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage, passwordInput);
+  });
+
   // 로그인 버튼 클릭 이벤트 핸들러
   signInButton.addEventListener('click', function (event) {
     event.preventDefault();
     emailInput.blur();
     passwordInput.blur();
+    passwordcheckInput.blur(); // 추가: 비밀번호 확인 input도 blur 처리
     const emailValue = emailInput.value.trim();
     const passwordValue = passwordInput.value.trim();
 
@@ -67,8 +82,16 @@ document.addEventListener('DOMContentLoaded', function () {
   // 비밀번호 보기/가리기 버튼 클릭 이벤트 핸들러
   watchPassword.addEventListener('click', function () {
     const eyeIcon = document.getElementById('eye-icon');
+    const eyeIconCheck = document.getElementById('eye-icon-check');
     const imgSrc = passwordInput.type === 'password' ? 'eye-on.svg' : 'eye-off.svg';
 
+    // 비밀번호 확인의 가시성 토글 함수 호출
+    togglePasswordVisibility(
+      passwordcheckInput,
+      eyeIcon,
+      imgSrc,
+      passwordcheckInput.type === 'password' ? 'text' : 'password'
+    );
     // 비밀번호 가시성 토글 함수 호출
     togglePasswordVisibility(
       passwordInput,

--- a/script/sign.js
+++ b/script/sign.js
@@ -12,6 +12,7 @@ import {
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
+
   const signInButton = document.getElementById('cta');
   const watchPassword = document.getElementById('eye-button');
 
@@ -45,6 +46,12 @@ document.addEventListener('DOMContentLoaded', function () {
     passwordInput.blur();
     const emailValue = emailInput.value.trim();
     const passwordValue = passwordInput.value.trim();
+
+    // 이메일 유효성 검증
+    if (!isEmailValid(emailValue)) {
+      displayError(emailInput, emailErrorMessage, '올바른 이메일 주소가 아닙니다.');
+      return;
+    }
 
     // 사용자 인증 성공 시, 페이지 이동
     if (authenticateUser(emailValue, passwordValue)) {

--- a/script/signin.js
+++ b/script/signin.js
@@ -1,0 +1,80 @@
+import {
+  createErrorMessage,
+  authenticateUser,
+  isEmailValid,
+  displayError,
+  clearError,
+  handlePasswordInputFocusOut,
+  handleEmailInputFocusIn,
+  togglePasswordVisibility,
+} from './utils.js';
+
+document.addEventListener('DOMContentLoaded', function () {
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const passwordcheckInput = document.getElementById('passwordcheck');
+  const signInButton = document.getElementById('cta');
+  const watchPassword = document.getElementById('eye-button');
+
+  // 에러 메시지 요소들 생성 및 초기화
+  const emailErrorMessage = createErrorMessage('email-error', '');
+  const passwordErrorMessage = createErrorMessage('password-error', '');
+
+  // 이메일, 비밀번호 입력란 뒤에 에러 메시지 요소 추가
+  emailInput.after(emailErrorMessage);
+  passwordInput.after(passwordErrorMessage);
+
+  // 이메일 입력란 focusin 이벤트 핸들러
+  emailInput.addEventListener('focusin', function () {
+    clearError(emailInput, emailErrorMessage);
+  });
+
+  // 이메일 입력란 focusout 이벤트 핸들러
+  emailInput.addEventListener('focusout', function () {
+    handleEmailInputFocusIn(emailInput, emailErrorMessage);
+  });
+
+  // 비밀번호 입력란 focusout 이벤트 핸들러
+  passwordInput.addEventListener('focusout', function () {
+    handlePasswordInputFocusOut(passwordInput, passwordErrorMessage);
+  });
+
+  // 로그인 버튼 클릭 이벤트 핸들러
+  signInButton.addEventListener('click', function (event) {
+    event.preventDefault();
+    emailInput.blur();
+    passwordInput.blur();
+    const emailValue = emailInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+
+    // 이메일 유효성 검증
+    if (!isEmailValid(emailValue)) {
+      displayError(emailInput, emailErrorMessage, '올바른 이메일 주소가 아닙니다.');
+      return;
+    }
+
+    // 사용자 인증 성공 시, 페이지 이동
+    if (authenticateUser(emailValue, passwordValue)) {
+      window.location.href = '../folder.html';
+      return;
+    }
+
+    // 사용자 인증 실패 시, 에러 메시지 표시
+    displayError(emailInput, emailErrorMessage, '이메일을 확인 해주세요.');
+    displayError(passwordInput, passwordErrorMessage, '비밀번호를 확인 해주세요.');
+  });
+
+  // 비밀번호 보기/가리기 버튼 클릭 이벤트 핸들러
+  watchPassword.addEventListener('click', function () {
+    const eyeIcon = document.getElementById('eye-icon');
+    const imgSrc = passwordInput.type === 'password' ? 'eye-on.svg' : 'eye-off.svg';
+
+    // 비밀번호의 가시성 토글 함수 호출
+    togglePasswordVisibility(
+      passwordInput,
+      eyeIcon,
+      imgSrc,
+      passwordInput.type === 'password' ? 'text' : 'password'
+    );
+  });
+});

--- a/script/signin.js
+++ b/script/signin.js
@@ -12,7 +12,6 @@ import {
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
-  const passwordcheckInput = document.getElementById('passwordcheck');
   const signInButton = document.getElementById('cta');
   const watchPassword = document.getElementById('eye-button');
 

--- a/script/signup.js
+++ b/script/signup.js
@@ -5,9 +5,9 @@ import {
   displayError,
   clearError,
   handlePasswordInputFocusOut,
-  handlePasswordCheckInputFocusOut,
   handleEmailInputFocusIn,
   togglePasswordVisibility,
+  checkDuplicateEmail,
 } from './utils.js';
 
 import { VALID_USER } from './constants.js';
@@ -37,12 +37,8 @@ document.addEventListener('DOMContentLoaded', function () {
   // 이메일 입력란 focusout 이벤트 핸들러
   emailInput.addEventListener('focusout', function () {
     handleEmailInputFocusIn(emailInput, emailErrorMessage);
-    // 추가: 이미 사용 중인 이메일 여부 검사
-    if (emailInput.value.trim() === VALID_USER.email) {
-      displayError(emailInput, emailErrorMessage, '이미 사용 중인 이메일입니다.');
-    }
+    checkDuplicateEmail(emailInput, emailErrorMessage);
   });
-
   // 비밀번호 입력란 focusout 이벤트 핸들러
   passwordInput.addEventListener('focusout', function () {
     handlePasswordInputFocusOut(passwordInput, passwordErrorMessage);

--- a/script/signup.js
+++ b/script/signup.js
@@ -5,12 +5,11 @@ import {
   displayError,
   clearError,
   handlePasswordInputFocusOut,
+  handlePasswordCheckInputFocusOut,
   handleEmailInputFocusIn,
   togglePasswordVisibility,
   checkDuplicateEmail,
 } from './utils.js';
-
-import { VALID_USER } from './constants.js';
 
 document.addEventListener('DOMContentLoaded', function () {
   const emailInput = document.getElementById('email');
@@ -50,22 +49,9 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   // 비밀번호 확인 입력란 focusout 이벤트 핸들러에서 비밀번호 일치 여부 체크
-  function handlePasswordCheckInputFocusOut(
-    passwordcheckInput,
-    passwordCheckErrorMessage,
-    passwordInput
-  ) {
-    const passwordCheckValue = passwordcheckInput.value.trim();
-    const passwordValue = passwordInput.value.trim();
-
-    if (!passwordCheckValue) {
-      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
-    } else if (passwordCheckValue !== passwordValue) {
-      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
-    } else {
-      clearError(passwordcheckInput, passwordCheckErrorMessage);
-    }
-  }
+  passwordcheckInput.addEventListener('focusout', function () {
+    handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage, passwordInput);
+  });
 
   // 로그인 버튼 클릭 이벤트 핸들러
   signInButton.addEventListener('click', function (event) {

--- a/script/signup.js
+++ b/script/signup.js
@@ -53,6 +53,15 @@ document.addEventListener('DOMContentLoaded', function () {
     handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage, passwordInput);
   });
 
+  // 비밀번호 입력란 focusin 이벤트 핸들러
+  passwordInput.addEventListener('focusin', function () {
+    clearError(passwordInput, passwordErrorMessage);
+  });
+
+  // 비밀번호 확인 입력란 focusin 이벤트 핸들러
+  passwordcheckInput.addEventListener('focusin', function () {
+    clearError(passwordcheckInput, passwordCheckErrorMessage);
+  });
   // 로그인 버튼 클릭 이벤트 핸들러
   signInButton.addEventListener('click', function (event) {
     event.preventDefault();

--- a/script/signup.js
+++ b/script/signup.js
@@ -28,8 +28,9 @@ document.addEventListener('DOMContentLoaded', function () {
   passwordInput.after(passwordErrorMessage);
   passwordcheckInput.after(passwordCheckErrorMessage); // 추가: 비밀번호 확인 에러 메시지
 
-  // 이메일 입력란 focusin 이벤트 핸들러
+  // 이메일 입력란 focusin 이벤트 핸들러 등록
   emailInput.addEventListener('focusin', function () {
+    handleEmailInputFocusIn(emailInput, emailErrorMessage);
     clearError(emailInput, emailErrorMessage);
   });
 

--- a/script/signup.js
+++ b/script/signup.js
@@ -66,6 +66,8 @@ document.addEventListener('DOMContentLoaded', function () {
       displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
     } else if (passwordCheckValue !== passwordValue) {
       displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
+    } else {
+      clearError(passwordcheckInput, passwordCheckErrorMessage);
     }
   }
 
@@ -105,7 +107,7 @@ document.addEventListener('DOMContentLoaded', function () {
     togglePasswordVisibility(
       passwordcheckInput,
       eyeIconCheck,
-      imgSrc,
+      imgSrcCheck,
       passwordcheckInput.type === 'password' ? 'text' : 'password'
     );
     // 비밀번호 가시성 토글 함수 호출
@@ -116,4 +118,6 @@ document.addEventListener('DOMContentLoaded', function () {
       passwordInput.type === 'password' ? 'text' : 'password'
     );
   });
+  // 추가: 비밀번호 확인 입력란의 에러 제거
+  clearError(passwordcheckInput, passwordCheckErrorMessage);
 });

--- a/script/signup.js
+++ b/script/signup.js
@@ -5,7 +5,6 @@ import {
   displayError,
   clearError,
   handlePasswordInputFocusOut,
-  handlePasswordCheckInputFocusOut,
   handleEmailInputFocusIn,
   togglePasswordVisibility,
   checkDuplicateEmail,
@@ -50,9 +49,25 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 
   // 비밀번호 확인 입력란 focusout 이벤트 핸들러에서 비밀번호 일치 여부 체크
-  passwordcheckInput.addEventListener('focusout', function () {
-    handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage, passwordInput);
-  });
+  function handlePasswordCheckInputFocusOut(
+    passwordcheckInput,
+    passwordCheckErrorMessage,
+    passwordInput
+  ) {
+    const passwordCheckValue = passwordcheckInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+
+    if (!passwordCheckValue) {
+      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
+      return;
+    }
+    if (passwordCheckValue !== passwordValue) {
+      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
+      return;
+    }
+
+    clearError(passwordcheckInput, passwordCheckErrorMessage);
+  }
 
   // 비밀번호 입력란 focusin 이벤트 핸들러
   passwordInput.addEventListener('focusin', function () {

--- a/script/signup.js
+++ b/script/signup.js
@@ -53,6 +53,22 @@ document.addEventListener('DOMContentLoaded', function () {
     handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage, passwordInput);
   });
 
+  // 비밀번호 확인 입력란 focusout 이벤트 핸들러에서 비밀번호 일치 여부 체크
+  function handlePasswordCheckInputFocusOut(
+    passwordcheckInput,
+    passwordCheckErrorMessage,
+    passwordInput
+  ) {
+    const passwordCheckValue = passwordcheckInput.value.trim();
+    const passwordValue = passwordInput.value.trim();
+
+    if (!passwordCheckValue) {
+      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
+    } else if (passwordCheckValue !== passwordValue) {
+      displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
+    }
+  }
+
   // 로그인 버튼 클릭 이벤트 핸들러
   signInButton.addEventListener('click', function (event) {
     event.preventDefault();
@@ -84,11 +100,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const eyeIcon = document.getElementById('eye-icon');
     const eyeIconCheck = document.getElementById('eye-icon-check');
     const imgSrc = passwordInput.type === 'password' ? 'eye-on.svg' : 'eye-off.svg';
-
+    const imgSrcCheck = passwordcheckInput.type === 'password' ? 'eye-on.svg' : 'eye-off.svg';
     // 비밀번호 확인의 가시성 토글 함수 호출
     togglePasswordVisibility(
       passwordcheckInput,
-      eyeIcon,
+      eyeIconCheck,
       imgSrc,
       passwordcheckInput.type === 'password' ? 'text' : 'password'
     );

--- a/script/utils.js
+++ b/script/utils.js
@@ -57,16 +57,17 @@ export function handlePasswordCheckInputFocusOut(
     displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
     return;
   }
-
-  clearError(passwordcheckInput, passwordCheckErrorMessage);
 }
 
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();
   if (!emailValue) {
     displayError(emailInput, emailErrorMessage, '이메일을 입력해 주세요.');
-  } else if (!isEmailValid(emailValue)) {
+    return;
+  }
+  if (!isEmailValid(emailValue)) {
     displayError(emailInput, emailErrorMessage, '이메일을 확인해 주세요.');
+    return;
   }
 }
 

--- a/script/utils.js
+++ b/script/utils.js
@@ -57,9 +57,8 @@ export function handlePasswordCheckInputFocusOut(
     displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
     return;
   }
-  {
-    clearError(passwordcheckInput, passwordCheckErrorMessage);
-  }
+
+  clearError(passwordcheckInput, passwordCheckErrorMessage);
 }
 
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -33,6 +33,13 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
   }
 }
 
+export function handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage) {
+  const passwordValue = passwordcheckInput.value;
+  if (!passwordValue) {
+    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 다릅니다.');
+  }
+}
+
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();
   if (!emailValue) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -41,25 +41,34 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
   clearError(passwordInput, passwordErrorMessage);
 }
 
-export function handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage) {
-  const passwordValue = passwordcheckInput.value;
-  if (!passwordValue) {
-    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
-  } else {
-    clearError(passwordcheckInput, passwordCheckErrorMessage);
-  }
-}
-
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();
   if (!emailValue) {
     displayError(emailInput, emailErrorMessage, '이메일을 입력해 주세요.');
-  } else if (!isEmailValid(emailValue)) {
-    displayError(emailInput, emailErrorMessage, '이메일을 확인해 주세요.');
+    return;
   }
+
+  if (!isEmailValid(emailValue)) {
+    displayError(emailInput, emailErrorMessage, '이메일을 확인해 주세요.');
+    return;
+  }
+
+  clearError(emailInput, emailErrorMessage);
+  return;
 }
 
 export function togglePasswordVisibility(passwordInput, eyeIcon, imgSrc, inputType) {
   eyeIcon.src = `../assets/icon/${imgSrc}`;
   passwordInput.type = inputType;
+}
+
+// 추가: 이미 사용 중인 이메일 여부 검사
+export function checkDuplicateEmail(emailInput, emailErrorMessage) {
+  if (isEmailAlreadyUsed(emailInput)) {
+    displayError(emailInput, emailErrorMessage, '이미 사용 중인 이메일입니다.');
+  }
+}
+
+export function isEmailAlreadyUsed(emailInput) {
+  return emailInput.value.trim() === VALID_USER.email;
 }

--- a/script/utils.js
+++ b/script/utils.js
@@ -41,20 +41,34 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
   clearError(passwordInput, passwordErrorMessage);
 }
 
+export function handlePasswordCheckInputFocusOut(
+  passwordcheckInput,
+  passwordCheckErrorMessage,
+  passwordInput
+) {
+  const passwordCheckValue = passwordcheckInput.value.trim();
+  const passwordValue = passwordInput.value.trim();
+
+  if (!passwordCheckValue) {
+    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
+    return;
+  }
+  if (passwordCheckValue !== passwordValue) {
+    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
+    return;
+  }
+  {
+    clearError(passwordcheckInput, passwordCheckErrorMessage);
+  }
+}
+
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();
   if (!emailValue) {
     displayError(emailInput, emailErrorMessage, '이메일을 입력해 주세요.');
-    return;
-  }
-
-  if (!isEmailValid(emailValue)) {
+  } else if (!isEmailValid(emailValue)) {
     displayError(emailInput, emailErrorMessage, '이메일을 확인해 주세요.');
-    return;
   }
-
-  clearError(emailInput, emailErrorMessage);
-  return;
 }
 
 export function togglePasswordVisibility(passwordInput, eyeIcon, imgSrc, inputType) {
@@ -62,7 +76,6 @@ export function togglePasswordVisibility(passwordInput, eyeIcon, imgSrc, inputTy
   passwordInput.type = inputType;
 }
 
-// 추가: 이미 사용 중인 이메일 여부 검사
 export function checkDuplicateEmail(emailInput, emailErrorMessage) {
   if (isEmailAlreadyUsed(emailInput)) {
     displayError(emailInput, emailErrorMessage, '이미 사용 중인 이메일입니다.');

--- a/script/utils.js
+++ b/script/utils.js
@@ -30,13 +30,17 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
   const passwordValue = passwordInput.value;
   if (!passwordValue) {
     displayError(passwordInput, passwordErrorMessage, '비밀번호를 입력해주세요');
+  } else {
+    clearError(passwordInput, passwordErrorMessage);
   }
 }
 
 export function handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage) {
   const passwordValue = passwordcheckInput.value;
   if (!passwordValue) {
-    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 다릅니다.');
+    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
+  } else {
+    clearError(passwordcheckInput, passwordCheckErrorMessage);
   }
 }
 

--- a/script/utils.js
+++ b/script/utils.js
@@ -26,7 +26,7 @@ export function clearError(inputElement, errorMessageElement) {
   errorMessageElement.innerText = '';
 }
 
-export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage) {
+export const handlePasswordInputFocusOut = (passwordInput, passwordErrorMessage) => {
   const passwordValue = passwordInput.value.trim();
 
   if (!PASSWORD_REGEX.test(passwordValue)) {
@@ -37,7 +37,7 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
     );
     return;
   }
-}
+};
 
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();

--- a/script/utils.js
+++ b/script/utils.js
@@ -39,24 +39,6 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
   }
 }
 
-export function handlePasswordCheckInputFocusOut(
-  passwordcheckInput,
-  passwordCheckErrorMessage,
-  passwordInput
-) {
-  const passwordCheckValue = passwordcheckInput.value.trim();
-  const passwordValue = passwordInput.value.trim();
-
-  if (!passwordCheckValue) {
-    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호를 다시 입력해주세요.');
-    return;
-  }
-  if (passwordCheckValue !== passwordValue) {
-    displayError(passwordcheckInput, passwordCheckErrorMessage, '비밀번호가 일치하지 않아요.');
-    return;
-  }
-}
-
 export function handleEmailInputFocusIn(emailInput, emailErrorMessage) {
   const emailValue = emailInput.value.trim();
   if (!emailValue) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -1,4 +1,4 @@
-import { VALID_USER, EMAIL_REGEX } from './constants.js';
+import { VALID_USER, EMAIL_REGEX, PASSWORD_REGEX } from './constants.js';
 
 export function createErrorMessage(id, text) {
   const errorMessage = document.getElementById(id) || document.createElement('div');
@@ -29,7 +29,7 @@ export function clearError(inputElement, errorMessageElement) {
 export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage) {
   const passwordValue = passwordInput.value.trim();
 
-  if (passwordValue.length < 8 || !(/[a-zA-Z]/.test(passwordValue) && /\d/.test(passwordValue))) {
+  if (!PASSWORD_REGEX.test(passwordValue)) {
     displayError(
       passwordInput,
       passwordErrorMessage,

--- a/script/utils.js
+++ b/script/utils.js
@@ -27,12 +27,18 @@ export function clearError(inputElement, errorMessageElement) {
 }
 
 export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage) {
-  const passwordValue = passwordInput.value;
-  if (!passwordValue) {
-    displayError(passwordInput, passwordErrorMessage, '비밀번호를 입력해주세요');
-  } else {
-    clearError(passwordInput, passwordErrorMessage);
+  const passwordValue = passwordInput.value.trim();
+
+  if (passwordValue.length < 8 || !(/[a-zA-Z]/.test(passwordValue) && /\d/.test(passwordValue))) {
+    displayError(
+      passwordInput,
+      passwordErrorMessage,
+      '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.'
+    );
+    return;
   }
+
+  clearError(passwordInput, passwordErrorMessage);
 }
 
 export function handlePasswordCheckInputFocusOut(passwordcheckInput, passwordCheckErrorMessage) {

--- a/script/utils.js
+++ b/script/utils.js
@@ -37,8 +37,6 @@ export function handlePasswordInputFocusOut(passwordInput, passwordErrorMessage)
     );
     return;
   }
-
-  clearError(passwordInput, passwordErrorMessage);
 }
 
 export function handlePasswordCheckInputFocusOut(

--- a/signin.html
+++ b/signin.html
@@ -38,7 +38,7 @@
             </button>
           </div>
         </div>
-        <button id="cta" type="submit">로그인</button>
+        <button id="btn_login" type="submit">로그인</button>
       </form>
       <div class="sns-box">
         <span class="sns-text text-medium">소셜 로그인</span>

--- a/signin.html
+++ b/signin.html
@@ -52,6 +52,6 @@
         </div>
       </div>
     </div>
-    <script type="module" src="script/sign.js"></script>
+    <script type="module" src="script/signin.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -41,7 +41,7 @@
             <label for="passwordcheck" class="sign-input-label text-medium">비밀번호 확인</label>
             <input id="passwordcheck" class="sign-input" type="password" />
             <button id="eye-button" type="button">
-              <img id="eye-icon" src="assets\icon\eye-off.svg" />
+              <img id="eye-icon-check" src="assets\icon\eye-off.svg" />
             </button>
           </div>
         </div>

--- a/signup.html
+++ b/signup.html
@@ -31,21 +31,21 @@
             <input id="email" class="sign-input" />
           </div>
           <div class="sign-input-box sign-password">
-            <label for="password" class="sign-input-label">비밀번호</label>
+            <label for="password" class="sign-input-label text-medium">비밀번호</label>
             <input id="password" class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="assets\icon\eye-off.svg" />
+            <button id="eye-button" type="button">
+              <img id="eye-icon" src="assets\icon\eye-off.svg" />
             </button>
           </div>
           <div class="sign-input-box sign-password">
-            <label for="passwordcheck" class="sign-input-label">비밀번호 확인</label>
+            <label for="passwordcheck" class="sign-input-label text-medium">비밀번호 확인</label>
             <input id="passwordcheck" class="sign-input" type="password" />
-            <button class="eye-button" type="button">
-              <img src="assets\icon\eye-off.svg" />
+            <button id="eye-button" type="button">
+              <img id="eye-icon" src="assets\icon\eye-off.svg" />
             </button>
           </div>
         </div>
-        <button class="cta" type="submit">회원가입</button>
+        <button id="cta" type="submit">회원가입</button>
       </form>
       <div class="sns-box">
         <span class="sns-text">다른 방식으로 가입하기</span>
@@ -59,5 +59,6 @@
         </div>
       </div>
     </div>
+    <script type="module" src="script/sign.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -45,7 +45,7 @@
             </button>
           </div>
         </div>
-        <button id="cta" type="submit">회원가입</button>
+        <button id="btn_login" type="submit">회원가입</button>
       </form>
       <div class="sns-box">
         <span class="sns-text">다른 방식으로 가입하기</span>

--- a/signup.html
+++ b/signup.html
@@ -59,6 +59,6 @@
         </div>
       </div>
     </div>
-    <script type="module" src="script/sign.js"></script>
+    <script type="module" src="script/signup.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -40,7 +40,7 @@
           <div class="sign-input-box sign-password">
             <label for="passwordcheck" class="sign-input-label text-medium">비밀번호 확인</label>
             <input id="passwordcheck" class="sign-input" type="password" />
-            <button id="eye-button" type="button">
+            <button id="eye-button-check" type="button">
               <img id="eye-icon-check" src="assets\icon\eye-off.svg" />
             </button>
           </div>

--- a/style/sign.css
+++ b/style/sign.css
@@ -97,6 +97,14 @@ body {
   height: 1.6rem;
 }
 
+#eye-button-check {
+  position: absolute;
+  top: 5.2rem;
+  right: 1.5rem;
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
 #cta {
   display: flex;
   justify-content: center;

--- a/style/sign.css
+++ b/style/sign.css
@@ -105,7 +105,7 @@ body {
   height: 1.6rem;
 }
 
-#cta {
+#btn_login {
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-
-

## 스크린샷
https://dazzling-croquembouche-795242.netlify.app/


## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.

## 멘토에게

- 사랑해요♥
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
