### PR TITLE
[김경주] Week5

### DIFF
--- a/folder.html
+++ b/folder.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Linkbrary</title>
+  </head>
+  <body>
+    <div>폴더 페이지입니다.</div>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,36 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="Linkbrary" key="title" />
-    <meta
-      name="description"
-      property="og:description"
-      content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요"
-      key="description"
-    />
+    <meta name="description" property="og:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" key="description" />
     <meta property="og:image" content="/public/img/preview.png" key="image" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@linkbrary" />
     <meta name="twitter:title" content="Linkbrary" />
-    <meta
-      name="twitter:description"
-      content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요"
-    />
+    <meta name="twitter:description" content="세상의 모든 정보를 쉽게 저장하고 관리해 보세요" />
     <meta name="twitter:image" content="/public/img/logo.svgr" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <link rel="stylesheet" href="/src/style.css" />
     <title>Linkbrary</title>
   </head>
   <body>
     <nav>
       <div class="gnb">
-        <a href="/"
-          ><img class="gnb-logo" src="/public/img/logo.svg" alt="홈 연결 로고"
-        /></a>
+        <a href="/"><img class="gnb-logo" src="/public/img/logo.svg" alt="홈 연결 로고" /></a>
         <a class="button button-login" href="signin.html">로그인</a>
       </div>
     </nav>
@@ -51,36 +36,21 @@
     <section>
       <div class="container">
         <div class="description">
-          <div class="main-description content1">
-            <span class="gra-text">원하는 링크</span>를 저장하세요
-          </div>
-          <p class="sub-description">
-            나중에 읽고 싶은 글, 다시 보고 싶은 영상, 사고 싶은 옷, 기억하고
-            싶은 모든 것을 한 공간에 저장하세요.
-          </p>
+          <div class="main-description content1"><span class="gra-text">원하는 링크</span>를 저장하세요</div>
+          <p class="sub-description">나중에 읽고 싶은 글, 다시 보고 싶은 영상, 사고 싶은 옷, 기억하고 싶은 모든 것을 한 공간에 저장하세요.</p>
         </div>
-        <img
-          class="content-img"
-          src="/public/img/_img1.png"
-          alt="원하는 링크를 저장"
-        />
+        <img class="content-img" src="/public/img/_img1.png" alt="원하는 링크를 저장" />
       </div>
     </section>
     <section>
       <div class="container">
-        <img
-          class="content-img"
-          src="/public/img/_img2.png"
-          alt="링크를 폴더로 관리"
-        />
+        <img class="content-img" src="/public/img/_img2.png" alt="링크를 폴더로 관리" />
         <div class="description">
           <div class="main-description content2">
             링크를 폴더로
             <span class="gra-text">관리</span>하세요
           </div>
-          <p class="sub-description">
-            나만의 폴더를 무제한으로 만들고 다양하게 활용할 수 있습니다.
-          </p>
+          <p class="sub-description">나만의 폴더를 무제한으로 만들고 다양하게 활용할 수 있습니다.</p>
         </div>
       </div>
     </section>
@@ -91,33 +61,20 @@
             저장한 링크를
             <span class="gra-text">공유</span>해 보세요
           </div>
-          <p class="sub-description">
-            여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게
-            쉽고 빠르게 링크를 공유해 보세요.
-          </p>
+          <p class="sub-description">여러 링크를 폴더에 담고 공유할 수 있습니다. 가족, 친구, 동료들에게 쉽고 빠르게 링크를 공유해 보세요.</p>
         </div>
-        <img
-          class="content-img"
-          src="/public/img/_img3.png"
-          alt="저장한 링크 공유"
-        />
+        <img class="content-img" src="/public/img/_img3.png" alt="저장한 링크 공유" />
       </div>
     </section>
     <section>
       <div class="container">
-        <img
-          class="content-img"
-          src="/public/img/_img4.png"
-          alt="저장한 링크 검색"
-        />
+        <img class="content-img" src="/public/img/_img4.png" alt="저장한 링크 검색" />
         <div class="description">
           <div class="main-description content4">
             저장한 링크를
             <span class="gra-text">검색</span>해 보세요
           </div>
-          <p class="sub-description">
-            중요한 정보들을 검색으로 쉽게 찾아보세요.
-          </p>
+          <p class="sub-description">중요한 정보들을 검색으로 쉽게 찾아보세요.</p>
         </div>
       </div>
     </section>
@@ -130,33 +87,11 @@
         </div>
         <div class="footer-sns">
           <a href="https://www.facebook.com" target="_blank">
-            <img
-              src="/public/img/facebook.svg"
-              rel="noreferrer noopener"
-              alt="facebook 연결 로고"
-            />
+            <img src="/public/img/facebook.svg" rel="noreferrer noopener" alt="facebook 연결 로고" />
           </a>
-          <a href="https://www.twitter.com" target="_blank"
-            ><img
-              src="/public/img/twitter.svg"
-              rel="noreferrer noopener"
-              alt="twitter 연결 로고"
-            />
-          </a>
-          <a href="https://www.youtube.com" target="_blank"
-            ><img
-              src="/public/img/youtube.svg"
-              rel="noreferrer noopener"
-              alt="youtube 연결 로고"
-            />
-          </a>
-          <a href="https://www.instagram.com" target="_blank"
-            ><img
-              src="/public/img/instagram.svg"
-              rel="noreferrer noopener"
-              alt="instagram 연결 로고"
-            />
-          </a>
+          <a href="https://www.twitter.com" target="_blank"><img src="/public/img/twitter.svg" rel="noreferrer noopener" alt="twitter 연결 로고" /> </a>
+          <a href="https://www.youtube.com" target="_blank"><img src="/public/img/youtube.svg" rel="noreferrer noopener" alt="youtube 연결 로고" /> </a>
+          <a href="https://www.instagram.com" target="_blank"><img src="/public/img/instagram.svg" rel="noreferrer noopener" alt="instagram 연결 로고" /> </a>
         </div>
       </div>
     </footer>

--- a/js/sign.js
+++ b/js/sign.js
@@ -1,0 +1,43 @@
+// // 이메일 입력
+// const querySelector = (selector) => document.querySelector(selector);
+
+// const emailInput = querySelector("#email-input");
+// const emailErrorMessage = querySelector("#email-error-message");
+
+// emailInput.addEventListener("focusout", validateEmailInput);
+
+// function validateEmailInput(emailInput, emailErrorMessage, isValidateEmail, showEmailErrorMessage, hideEmailErrorMessage) {
+//   const email = emailInput.value.trim();
+
+//   if (email === "") {
+//     showEmailErrorMessage(emailErrorMessage, "이메일을 입력해 주세요.");
+//     return;
+//   }
+
+//   if (!isValidateEmail(email)) {
+//     showEmailErrorMessage(emailErrorMessage, "올바른 이메일 주소가 아닙니다.");
+//     return;
+//   }
+
+//   hideEmailErrorMessage(emailInput, emailErrorMessage);
+// }
+
+// function isValidateEmail(email) {
+//   return EMAIL_REGEX.test(email);
+// }
+
+// function showEmailErrorMessage(message) {
+//   emailErrorMessage.textContent = message;
+//   emailErrorMessage.classList.add("show");
+//   emailInput.classList.add("sign-input-error");
+//   emailInput.classList.add("error-focus");
+// }
+
+// function hideEmailErrorMessage() {
+//   emailErrorMessage.textContent = "";
+//   emailErrorMessage.classList.remove("show");
+//   emailInput.classList.remove("sign-input-error");
+//   emailInput.classList.remove("error-focus");
+// }
+
+// export { emailInput, emailErrorMessage, validateEmailInput, isValidateEmail, showEmailErrorMessage, hideEmailErrorMessage };

--- a/js/signin.js
+++ b/js/signin.js
@@ -1,72 +1,80 @@
-const emailInput = document.querySelector("#email-input");
-const passwordInput = document.querySelector("#password-input");
-const emailErrorMessage = document.querySelector("#email-error-message");
-const passwordErrorMessage = document.querySelector("#password-error-message");
-const loginForm = document.querySelector("#login-form");
+const querySelector = (selector) => document.querySelector(selector);
 
-const eyeOffButton = document.querySelector(".eye-off");
-const eyeOnButton = document.querySelector(".eye-on");
+const emailInput = querySelector("#email-input");
+const passwordInput = querySelector("#password-input");
+const emailErrorMessage = querySelector("#email-error-message");
+const passwordErrorMessage = querySelector("#password-error-message");
+const loginForm = querySelector("#login-form");
+
+const eyeOffButton = querySelector("#eye-off");
+const eyeOnButton = querySelector("#eye-on");
 
 const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
 
 // 이메일 입력
-emailInput.addEventListener("focusout", checkEmailInput);
-emailInput.addEventListener("focus", resetInputStyle);
 
-function checkEmailInput() {
-  if (emailInput.value.trim() === "") {
+emailInput.addEventListener("focusout", validateEmailInput);
+
+function validateEmailInput() {
+  const email = emailInput.value.trim();
+
+  if (email === "") {
     showEmailErrorMessage("이메일을 입력해 주세요.");
-  } else if (!validateEmail(emailInput.value.trim())) {
-    showEmailErrorMessage("올바른 이메일 주소가 아닙니다.");
-  } else {
-    hideErrorMessage();
+    return;
   }
+
+  if (!isValidateEmail(email)) {
+    showEmailErrorMessage("올바른 이메일 주소가 아닙니다.");
+    return;
+  }
+
+  hideEmailErrorMessage();
 }
 
-function validateEmail(email) {
+function isValidateEmail(email) {
   return EMAIL_REGEX.test(email);
 }
 
 function showEmailErrorMessage(message) {
   emailErrorMessage.textContent = message;
-  emailErrorMessage.style.display = "block";
+  emailErrorMessage.classList.add("show");
   emailInput.classList.add("sign-input-error");
+  emailInput.classList.add("error-focus");
 }
 
-function hideErrorMessage() {
-  emailErrorMessage.style.display = "none";
+function hideEmailErrorMessage() {
+  emailErrorMessage.textContent = "";
+  emailErrorMessage.classList.remove("show");
   emailInput.classList.remove("sign-input-error");
-}
-
-function resetInputStyle() {
-  hideErrorMessage();
+  emailInput.classList.remove("error-focus");
 }
 
 // 비밀번호 입력
-passwordInput.addEventListener("focusout", checkPasswordInput);
-passwordInput.addEventListener("focus", resetPasswordInputStyle);
+passwordInput.addEventListener("focusout", validatePasswordInput);
 
-function checkPasswordInput() {
-  if (passwordInput.value.trim() === "") {
+function validatePasswordInput() {
+  const password = passwordInput.value.trim();
+
+  if (password === "") {
     showPasswordErrorMessage("비밀번호를 입력해 주세요.");
-  } else {
-    hidePasswordErrorMessage();
+    return;
   }
+
+  hidePasswordErrorMessage();
 }
 
 function showPasswordErrorMessage(message) {
   passwordErrorMessage.textContent = message;
-  passwordErrorMessage.style.display = "block";
+  passwordErrorMessage.classList.add("show");
   passwordInput.classList.add("sign-input-error");
+  passwordInput.classList.add("error-focus");
 }
 
 function hidePasswordErrorMessage() {
-  passwordErrorMessage.style.display = "none";
+  passwordErrorMessage.textContent = "";
+  passwordErrorMessage.classList.remove("show");
   passwordInput.classList.remove("sign-input-error");
-}
-
-function resetPasswordInputStyle() {
-  hidePasswordErrorMessage();
+  passwordInput.classList.remove("error-focus");
 }
 
 // 이메일, 비밀번호 제출
@@ -77,28 +85,35 @@ function formSubmit(event) {
 
   const email = emailInput.value.trim();
   const password = passwordInput.value.trim();
+  const testEmail = "test@codeit.com";
+  const testPassword = "codeit101";
 
-  if (email === "test@codeit.com" && password === "codeit101") {
+  if (email === testEmail && password === testPassword) {
     window.location.href = "/folder";
-  } else {
-    if (email !== "test@codeit.com") {
-      showEmailErrorMessage("이메일을 확인해 주세요.");
-    }
-    if (password !== "codeit101") {
-      showPasswordErrorMessage("비밀번호를 확인해 주세요.");
-    }
+    return;
+  }
+
+  if (email !== testEmail) {
+    showEmailErrorMessage("이메일을 확인해 주세요.");
+  }
+
+  if (password !== testPassword) {
+    showPasswordErrorMessage("비밀번호를 확인해 주세요.");
   }
 }
 
-// 눈 모양 아이콘 클릭시 문자열 보이게
-eyeOffButton.addEventListener("click", function () {
-  passwordInput.type = "text";
-  eyeOffButton.style.display = "none";
-  eyeOnButton.style.display = "block";
-});
+// 눈 아이콘 클릭시 문자열 보이거나 숨기기
+eyeOffButton.addEventListener("click", handleClickEyeOffButton);
+eyeOnButton.addEventListener("click", handleClickEyeOnButton);
 
-eyeOnButton.addEventListener("click", function () {
+function handleClickEyeOffButton() {
+  passwordInput.type = "text";
+  eyeOffButton.classList.add("hide");
+  eyeOnButton.classList.remove("hide");
+}
+
+function handleClickEyeOnButton() {
   passwordInput.type = "password";
-  eyeOnButton.style.display = "none";
-  eyeOffButton.style.display = "block";
-});
+  eyeOffButton.classList.remove("hide");
+  eyeOnButton.classList.add("hide");
+}

--- a/js/signin.js
+++ b/js/signin.js
@@ -12,7 +12,6 @@ const eyeOnButton = querySelector("#eye-on");
 const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
 
 // 이메일 입력
-
 emailInput.addEventListener("focusout", validateEmailInput);
 
 function validateEmailInput() {

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,195 @@
+const querySelector = (selector) => document.querySelector(selector);
+
+const emailInput = querySelector("#email-input");
+const passwordInput = querySelector("#password-input");
+const emailErrorMessage = querySelector("#email-error-message");
+const passwordErrorMessage = querySelector("#password-error-message");
+const passwordConfirmInput = querySelector("#password-confirm-input");
+const passwordConfirmErrorMessage = querySelector("#password-confirm-error-message");
+const loginForm = querySelector("#login-form");
+
+const eyeOffButton = querySelector("#eye-off");
+const eyeOnButton = querySelector("#eye-on");
+const eyeOffConfirmButton = querySelector("#eye-off-confirm");
+const eyeOnConfirmButton = querySelector("#eye-on-confirm");
+
+const EMAIL_REGEX = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,6}$/;
+const PASSWORD_REGEX = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+
+// 이메일 입력
+emailInput.addEventListener("focusout", validateEmailInput);
+
+function isValidateEmail(email) {
+  return EMAIL_REGEX.test(email);
+}
+
+function validateEmailInput() {
+  const email = emailInput.value.trim();
+  const testEmail = "test@codeit.com";
+
+  if (email === "") {
+    showEmailErrorMessage("이메일을 입력해 주세요.");
+    return;
+  }
+
+  if (!isValidateEmail(email)) {
+    showEmailErrorMessage("올바른 이메일 주소가 아닙니다.");
+    return;
+  }
+
+  if (email === testEmail) {
+    showEmailErrorMessage("이미 사용 중인 이메일입니다.");
+    return;
+  }
+
+  hideEmailErrorMessage();
+}
+
+function showEmailErrorMessage(message) {
+  emailErrorMessage.textContent = message;
+  emailErrorMessage.classList.add("show");
+  emailInput.classList.add("sign-input-error");
+  emailInput.classList.add("error-focus");
+}
+
+function hideEmailErrorMessage() {
+  emailErrorMessage.textContent = "";
+  emailErrorMessage.classList.remove("show");
+  emailInput.classList.remove("sign-input-error");
+  emailInput.classList.remove("error-focus");
+}
+
+// 비밀번호 입력
+passwordInput.addEventListener("focusout", validatePasswordInput);
+
+function isValidatePassword(password) {
+  return PASSWORD_REGEX.test(password);
+}
+
+function validatePasswordInput() {
+  const password = passwordInput.value.trim();
+
+  if (password === "") {
+    showPasswordErrorMessage("비밀번호를 입력해 주세요.");
+    return;
+  }
+
+  if (!isValidatePassword(password)) {
+    showPasswordErrorMessage("비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.");
+    return;
+  }
+
+  hidePasswordErrorMessage();
+}
+
+function showPasswordErrorMessage(message) {
+  passwordErrorMessage.textContent = message;
+  passwordErrorMessage.classList.add("show");
+  passwordInput.classList.add("sign-input-error");
+  passwordInput.classList.add("error-focus");
+}
+
+function hidePasswordErrorMessage() {
+  passwordErrorMessage.textContent = "";
+  passwordErrorMessage.classList.remove("show");
+  passwordInput.classList.remove("sign-input-error");
+  passwordInput.classList.remove("error-focus");
+}
+
+// 비밀번호 확인
+passwordConfirmInput.addEventListener("focusout", validatePasswordConfirmInput);
+
+function validatePasswordConfirmInput() {
+  const password = passwordInput.value.trim();
+  const passwordConfirm = passwordConfirmInput.value.trim();
+
+  if (password !== passwordConfirm) {
+    showPasswordConfirmErrorMessage("비밀번호가 일치하지 않아요.");
+    return;
+  }
+
+  hidePasswordConfirmErrorMessage();
+}
+
+function showPasswordConfirmErrorMessage(message) {
+  passwordConfirmErrorMessage.textContent = message;
+  passwordConfirmErrorMessage.classList.add("show");
+  passwordConfirmInput.classList.add("sign-input-error");
+  passwordConfirmInput.classList.add("error-focus");
+}
+
+function hidePasswordConfirmErrorMessage() {
+  passwordConfirmErrorMessage.textContent = "";
+  passwordConfirmErrorMessage.classList.remove("show");
+  passwordConfirmInput.classList.remove("sign-input-error");
+  passwordConfirmInput.classList.remove("error-focus");
+}
+
+// 이메일, 비밀번호, 비밀번호 확인 제출
+loginForm.addEventListener("submit", formSubmit);
+
+function formSubmit(event) {
+  event.preventDefault();
+
+  const email = emailInput.value.trim();
+  const password = passwordInput.value.trim();
+  const passwordConfirm = passwordConfirmInput.value.trim();
+
+  let isValid = true;
+
+  if (!isValidateEmail(email)) {
+    showEmailErrorMessage("올바른 이메일 주소가 아닙니다.");
+    isValid = false;
+  } else {
+    hideEmailErrorMessage();
+  }
+
+  if (!isValidatePassword(password)) {
+    showPasswordErrorMessage("비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.");
+    isValid = false;
+  } else {
+    hidePasswordErrorMessage();
+  }
+
+  if (password !== passwordConfirm) {
+    showPasswordConfirmErrorMessage("비밀번호가 일치하지 않아요.");
+    isValid = false;
+  } else {
+    hidePasswordConfirmErrorMessage();
+  }
+
+  if (isValid) {
+    window.location.href = "/folder";
+    return;
+  }
+}
+
+// 눈 아이콘 클릭시 문자열 보이거나 숨기기
+eyeOffButton.addEventListener("click", handleClickEyeOffButton);
+eyeOnButton.addEventListener("click", handleClickEyeOnButton);
+eyeOffConfirmButton.addEventListener("click", handleClickEyeOffConfirmButton);
+eyeOnConfirmButton.addEventListener("click", handleClickEyeOnConfirmButton);
+
+function handleClickEyeOffButton() {
+  passwordInput.type = "text";
+  eyeOffButton.classList.add("hide");
+  eyeOnButton.classList.remove("hide");
+}
+
+function handleClickEyeOnButton() {
+  passwordInput.type = "password";
+  eyeOffButton.classList.remove("hide");
+  eyeOnButton.classList.add("hide");
+}
+
+function handleClickEyeOffConfirmButton() {
+  passwordConfirmInput.type = "text";
+  eyeOffConfirmButton.classList.add("hide");
+  eyeOnConfirmButton.classList.remove("hide");
+}
+
+function handleClickEyeOnConfirmButton() {
+  passwordConfirmInput.type = "password";
+  eyeOffConfirmButton.classList.remove("hide");
+  eyeOnConfirmButton.classList.add("hide");
+}

--- a/signin.html
+++ b/signin.html
@@ -51,6 +51,6 @@
         </div>
       </div>
     </main>
+    <script type="module" src="/js/signin.js"></script>
   </body>
-  <script src="/js/signin.js"></script>
 </html>

--- a/signin.html
+++ b/signin.html
@@ -3,12 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <link rel="stylesheet" href="/src/signin.css" />
     <title>Linkbrary</title>
   </head>
@@ -16,12 +11,7 @@
     <main>
       <div class="login-form">
         <div class="header">
-          <a href="/"
-            ><img
-              class="header-logo"
-              src="/public/img/logo.svg"
-              alt="홈 연결 로고"
-          /></a>
+          <a href="/"><img class="header-logo" src="/public/img/logo.svg" alt="홈 연결 로고" /></a>
           <p class="header-message">
             회원이 아니신가요?
             <a class="header-signup-link" href="signup.html">회원 가입하기</a>
@@ -30,29 +20,21 @@
         <form id="login-form" action="">
           <div class="email-container">
             <label class="sign-label" for="email-input">이메일</label>
-            <input
-              id="email-input"
-              class="sign-input"
-              type="email"
-              placeholder="codeit@codeit.com"
-            />
+            <input id="email-input" class="sign-input" type="email" placeholder="codeit@codeit.com" />
             <div id="email-error-message" class="error-message"></div>
           </div>
           <div class="password-container">
             <label class="sign-label" for="password-input">비밀번호</label>
-            <input
-              id="password-input"
-              class="sign-input"
-              name="password"
-              type="password"
-            />
+            <div class="password-toggle">
+              <input id="password-input" class="sign-input" name="password" type="password" />
+              <button id="eye-off" type="button">
+                <img src="/public/img/eye-off.svg" />
+              </button>
+              <button id="eye-on" class="hide" type="button">
+                <img src="/public/img/eye-on.svg" />
+              </button>
+            </div>
             <div id="password-error-message" class="error-message"></div>
-            <button class="eye-off" type="button">
-              <img src="/public/img/eye-off.svg" />
-            </button>
-            <button class="eye-on" type="button" style="display: none">
-              <img src="/public/img/eye-on.svg" />
-            </button>
           </div>
           <button class="button-login" type="submit">로그인</button>
         </form>
@@ -63,10 +45,7 @@
           <a class="social-img google-img" href="https://www.google.com">
             <img src="/public/img/google.png" alt="google 로그인" />
           </a>
-          <a
-            class="social-img kakao-img"
-            href="https://www.kakaocorp.com/page/"
-          >
+          <a class="social-img kakao-img" href="https://www.kakaocorp.com/page/">
             <img src="/public/img/kakao.svg" alt="kakao 로그인" />
           </a>
         </div>

--- a/signup.html
+++ b/signup.html
@@ -3,12 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="stylesheet"
-      as="style"
-      crossorigin
-      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
     <link rel="stylesheet" href="/src/signup.css" />
     <title>Linkbrary</title>
   </head>
@@ -16,50 +11,43 @@
     <main>
       <div class="login-form">
         <div class="header">
-          <a href="/"
-            ><img
-              class="header-logo"
-              src="/public/img/logo.svg"
-              alt="홈 연결 로고"
-          /></a>
+          <a href="/"><img class="header-logo" src="/public/img/logo.svg" alt="홈 연결 로고" /></a>
           <p class="header-message">
             이미 회원이신가요?
             <a class="header-signup-link" href="signin.html">로그인 하기</a>
           </p>
         </div>
-        <form action="">
+        <form id="login-form" action="">
           <div class="email-container">
-            <label class="sign-label" for="email">이메일</label>
-            <input
-              id="email"
-              class="sign-input"
-              type="email"
-              placeholder="codeit@codeit.com"
-            />
+            <label class="sign-label" for="email-input">이메일</label>
+            <input id="email-input" class="sign-input" type="email" placeholder="codeit@codeit.com" />
+            <div id="email-error-message" class="error-message"></div>
           </div>
           <div class="password-container">
-            <label class="sign-label" for="password">비밀번호</label>
-            <input
-              id="password"
-              class="sign-input"
-              name="password"
-              type="password"
-            />
-            <button class="eye-off" type="button">
-              <img src="/public/img/eye-off.svg" />
-            </button>
+            <label class="sign-label" for="password-input">비밀번호</label>
+            <div class="password-toggle">
+              <input id="password-input" class="sign-input" name="password" type="password" />
+              <button id="eye-off" type="button">
+                <img src="/public/img/eye-off.svg" />
+              </button>
+              <button id="eye-on" class="hide" type="button">
+                <img src="/public/img/eye-on.svg" />
+              </button>
+            </div>
+            <div id="password-error-message" class="error-message"></div>
           </div>
           <div class="password-confirm-container">
-            <label class="sign-label" for="password">비밀번호 확인</label>
-            <input
-              id="password"
-              class="sign-input"
-              name="password"
-              type="password"
-            />
-            <button class="eye-off" type="button">
-              <img src="/public/img/eye-off.svg" />
-            </button>
+            <label class="sign-label" for="password-confirm-input">비밀번호 확인</label>
+            <div class="password-confirm-toggle">
+              <input id="password-confirm-input" class="sign-input" name="password" type="password" />
+              <button id="eye-off-confirm" type="button">
+                <img src="/public/img/eye-off.svg" />
+              </button>
+              <button id="eye-on-confirm" class="hide" type="button">
+                <img src="/public/img/eye-on.svg" />
+              </button>
+            </div>
+            <div id="password-confirm-error-message" class="error-message"></div>
           </div>
           <button class="button-login" type="submit">회원가입</button>
         </form>
@@ -70,14 +58,12 @@
           <a class="social-img google-img" href="https://www.google.com">
             <img src="/public/img/google.png" alt="google 로그인" />
           </a>
-          <a
-            class="social-img kakao-img"
-            href="https://www.kakaocorp.com/page/"
-          >
+          <a class="social-img kakao-img" href="https://www.kakaocorp.com/page/">
             <img src="/public/img/kakao.svg" alt="kakao 로그인" />
           </a>
         </div>
       </div>
     </main>
+    <script src="/js/signup.js"></script>
   </body>
 </html>

--- a/src/signin.css
+++ b/src/signin.css
@@ -95,7 +95,7 @@ main {
 }
 
 .sign-input.error-focus:focus {
-  outline: none; /* 에러가 있는 경우 포커스 테두리를 제거 */
+  outline: none;
 }
 
 .password-toggle {

--- a/src/signin.css
+++ b/src/signin.css
@@ -94,6 +94,18 @@ main {
   outline: 0.1rem solid var(--Linkbrary-primary-color);
 }
 
+.sign-input.error-focus:focus {
+  outline: none; /* 에러가 있는 경우 포커스 테두리를 제거 */
+}
+
+.password-toggle {
+  position: relative;
+}
+
+#password-input {
+  width: 100%;
+}
+
 .error-message {
   margin-top: 0.6rem;
   font-size: 1.4rem;
@@ -110,14 +122,23 @@ button {
   cursor: pointer;
 }
 
-.eye-off,
-.eye-on {
+#eye-off,
+#eye-on {
   position: absolute;
-  bottom: 2.6rem;
+  top: 50%;
   right: 1.5rem;
   width: 1.6rem;
   height: 1.6rem;
   cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.show {
+  display: block;
+}
+
+.hide {
+  display: none;
 }
 
 .button-login {

--- a/src/signup.css
+++ b/src/signup.css
@@ -94,6 +94,30 @@ main {
   outline: 0.1rem solid var(--Linkbrary-primary-color);
 }
 
+.sign-input.error-focus:focus {
+  outline: none;
+}
+
+.password-toggle {
+  position: relative;
+}
+
+#password-input,
+#password-confirm-input {
+  width: 100%;
+}
+
+.error-message {
+  margin-top: 0.6rem;
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  color: var(--Linkbrary-red);
+}
+
+.sign-input-error {
+  border: 0.1rem solid var(--Linkbrary-red);
+}
+
 button {
   border: none;
   cursor: pointer;
@@ -104,12 +128,25 @@ button {
   position: relative;
 }
 
-.eye-off {
+#eye-off,
+#eye-on,
+#eye-off-confirm,
+#eye-on-confirm {
   position: absolute;
-  bottom: 2rem;
+  top: 50%;
   right: 1.5rem;
   width: 1.6rem;
   height: 1.6rem;
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.show {
+  display: block;
+}
+
+.hide {
+  display: none;
 }
 
 .button-login {

--- a/src/style.css
+++ b/src/style.css
@@ -288,8 +288,19 @@ footer {
   }
 
   .sub-description {
-    white-space: initial;
+    white-space: pre-wrap;
+    word-break: keep-all;
     font-size: 1.5rem;
+  }
+
+  .main-description {
+    order: 1;
+  }
+  .content-img {
+    order: 2;
+  }
+  .sub-description {
+    order: 3;
   }
 
   footer {
@@ -347,6 +358,10 @@ footer {
 
   .description {
     width: 26.2rem;
+  }
+
+  .sub-description {
+    word-break: keep-all;
   }
 
   .content-img {


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-
-

## 스크린샷

https://weekly-misson.netlify.app/

## 멘토에게

- 모듈화 해보려고 했는데 시간이 오래걸릴 것 같아서 일단 제출 먼저 합니다..
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
