### PR TITLE
[김수정] week5

### DIFF
--- a/signin.html
+++ b/signin.html
@@ -24,6 +24,7 @@
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
             <input class="sign-input" />
+            <p id="email-error-message" class="email-error-message"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-box sign-password">비밀번호</label>

--- a/signup.html
+++ b/signup.html
@@ -29,10 +29,12 @@
           <div class="sign-input-box">
             <label class="sign-input-label">이메일</label>
             <input class="sign-input"/>
+            <p id="email-error-message" class="error-message"></p>
           </div>
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호</label>
             <input class="sign-input" type="password"/>
+            <p id="password-error-message" class="error-message"></p>
             <button class="eye-button" type="button">
               <img src="./image/eye-off.svg"/>
             </button>
@@ -40,6 +42,7 @@
           <div class="sign-input-box sign-password">
             <label class="sign-input-label">비밀번호 확인</label>
             <input class="sign-input" type="password"/>
+            <p id="confirm-password-error-message" class="error-message"></p>
             <button class="eye-button" type="button">
               <img src="./image/eye-off.svg"/>
             </button>

--- a/src/sign.js
+++ b/src/sign.js
@@ -1,66 +1,80 @@
 import {
-    setInputError,
-    removeInputError,
-    isEmailValid,
-    togglePassword,
-    TEST_USER,
-  } from "./utils.js";
-  
-  const emailInput = document.querySelector("#email");
-  const emailErrorMessage = document.querySelector("#email-error-message");
-  emailInput.addEventListener("focusout", (event) => validateEmailInput(event.target.value));
-  
-  const validateEmailInput = (email) => {
-    if (email === "") {
-      setInputError({ input: emailInput, errorMessage: emailErrorMessage }, "이메일을 입력해주세요.");
-      return;
-    }
-    if (!isEmailValid(email)) {
-      setInputError(
-        { input: emailInput, errorMessage: emailErrorMessage },
-        "올바른 이메일 주소가 아닙니다."
-      );
-      return;
-    }
-    removeInputError({ input: emailInput, errorMessage: emailErrorMessage });
+  setInputError,
+  removeInputError,
+  isEmailValid,
+  togglePassword,
+  TEST_USER,
+} from "./utils.js";
+
+const emailInput = document.querySelector("#email");
+const emailErrorMessage = document.querySelector("#email-error-message");
+
+const validateEmailInput = (email) => {
+  if (email === "") {
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "이메일을 입력해주세요."
+    );
+    return;
   }
-  
-  const passwordInput = document.querySelector("#password");
-  const passwordErrorMessage = document.querySelector("#password-error-message");
-  passwordInput.addEventListener("focusout", (event) => validatePasswordInput(event.target.value));
-  
-  const validatePasswordInput = (password) => {
-    if (password === "") {
-      setInputError(
-        { input: passwordInput, errorMessage: passwordErrorMessage },
-        "비밀번호를 입력해주세요."
-      );
-      return;
-    }
-    removeInputError({ input: passwordInput, errorMessage: passwordErrorMessage });
+  if (!isEmailValid(email)) {
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "올바른 이메일 주소가 아닙니다."
+    );
+    return;
   }
-  
-  const passwordToggleButton = document.querySelector("#password-toggle");
-  passwordToggleButton.addEventListener("click", () =>
-    togglePassword(passwordInput, passwordToggleButton)
-  );
-  
-  const signForm = document.querySelector("#form");
-  signForm.addEventListener("submit", submitForm);
-  
-  const submitForm = (event) => {
-    event.preventDefault();
-  
-    const isTestUser =
-      emailInput.value === TEST_USER.email && passwordInput.value === TEST_USER.password;
-  
-    if (isTestUser) {
-      location.href = "/folder";
-      return;
-    }
-    setInputError({ input: emailInput, errorMessage: emailErrorMessage }, "이메일을 확인해주세요.");
+  removeInputError({ input: emailInput, errorMessage: emailErrorMessage });
+};
+
+emailInput.addEventListener("focusout", (event) => validateEmailInput(event.target.value));
+
+const passwordInput = document.querySelector("#password");
+const passwordErrorMessage = document.querySelector("#password-error-message");
+
+const validatePasswordInput = (password) => {
+  if (password === "") {
     setInputError(
       { input: passwordInput, errorMessage: passwordErrorMessage },
-      "비밀번호를 확인해주세요."
+      "비밀번호를 입력해주세요."
     );
+    return;
   }
+  removeInputError({
+    input: passwordInput,
+    errorMessage: passwordErrorMessage,
+  });
+};
+
+passwordInput.addEventListener("focusout", (event) =>
+  validatePasswordInput(event.target.value)
+);
+
+const passwordToggleButton = document.querySelector("#password-toggle");
+passwordToggleButton.addEventListener("click", () =>
+  togglePassword(passwordInput, passwordToggleButton)
+);
+
+const submitForm = (event) => {
+  event.preventDefault();
+
+  const isTestUser =
+    emailInput.value === TEST_USER.email &&
+    passwordInput.value === TEST_USER.password;
+
+  if (isTestUser) {
+    location.href = "/folder";
+    return;
+  }
+  setInputError(
+    { input: emailInput, errorMessage: emailErrorMessage },
+    "이메일을 확인해주세요."
+  );
+  setInputError(
+    { input: passwordInput, errorMessage: passwordErrorMessage },
+    "비밀번호를 확인해주세요."
+  );
+};
+
+const signForm = document.querySelector("#form");
+signForm.addEventListener("submit", submitForm);

--- a/src/signin.js
+++ b/src/signin.js
@@ -1,0 +1,81 @@
+import {
+  setInputError,
+  removeInputError,
+  isEmailValid,
+  togglePassword,
+  TEST_USER,
+} from "./utils.js";
+
+const emailInput = document.querySelector("#email");
+const emailErrorMessage = document.querySelector("#email-error-message");
+
+const validateEmailInput = (email) => {
+  if (email === "") {
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "이메일을 입력해주세요."
+    );
+    return;
+  }
+  if (!isEmailValid(email)) {
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "올바른 이메일 주소가 아닙니다."
+    );
+    return;
+  }
+  removeInputError({ input: emailInput, errorMessage: emailErrorMessage });
+};
+
+emailInput.addEventListener("focusout", (event) => validateEmailInput(event.target.value));
+
+
+const passwordInput = document.querySelector("#password");
+const passwordErrorMessage = document.querySelector("#password-error-message");
+
+const validatePasswordInput = (password) => {
+  if (password === "") {
+    setInputError(
+      { input: passwordInput, errorMessage: passwordErrorMessage },
+      "비밀번호를 입력해주세요."
+    );
+    return;
+  }
+  removeInputError({
+    input: passwordInput,
+    errorMessage: passwordErrorMessage,
+  });
+};
+
+passwordInput.addEventListener("focusout", (event) =>
+  validatePasswordInput(event.target.value)
+);
+
+const passwordToggleButton = document.querySelector("#password-toggle");
+passwordToggleButton.addEventListener("click", () =>
+  togglePassword(passwordInput, passwordToggleButton)
+);
+
+const submitForm = (event) => {
+  event.preventDefault();
+
+  const isTestUser =
+    emailInput.value === TEST_USER.email &&
+    passwordInput.value === TEST_USER.password;
+
+  if (isTestUser) {
+    location.href = "/folder";
+    return;
+  }
+  setInputError(
+    { input: emailInput, errorMessage: emailErrorMessage },
+    "이메일을 확인해주세요."
+  );
+  setInputError(
+    { input: passwordInput, errorMessage: passwordErrorMessage },
+    "비밀번호를 확인해주세요."
+  );
+};
+
+const signForm = document.querySelector("#form");
+signForm.addEventListener("submit", submitForm);

--- a/src/signup.js
+++ b/src/signup.js
@@ -1,0 +1,138 @@
+import {
+  setInputError,
+  removeInputError,
+  isEmailValid,
+  togglePassword,
+  TEST_USER,
+} from "./utils.js";
+
+const emailInput = document.querySelector("#email");
+const emailErrorMessage = document.querySelector("#email-error-message");
+
+const validateEmailInput = (email) => {
+  if (email === "") {
+    // 이메일 주소 미입력
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "이메일을 입력해주세요."
+    );
+    return false;
+  }
+
+  if (!isEmailValid) {
+    // 잘못된 이메일 입력
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "올바른 이메일 주소가 아닙니다."
+    );
+    return false;
+  }
+
+  if (email === TEST_USER.email) {
+    // 중복 이메일
+    setInputError(
+      { input: emailInput, errorMessage: emailErrorMessage },
+      "이미 사용 중인 이메일입니다."
+    );
+    return false;
+  }
+  removeInputError({ input: emailInput, errorMessage: emailErrorMessage });
+  return true;
+};
+
+emailInput.addEventListener("focusout", (event) =>
+  validateEmailInput(event.target.value)
+);
+
+const passwordInput = document.querySelector("#password");
+const passwordErrorMessage = document.querySelector("#password-error-message");
+
+const validatePasswordInput = (password) => {
+  if (password === "" || !isPasswordValid(password)) {
+    setInputError(
+      { input: passwordInput, errorMessage: passwordErrorMessage },
+      "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    );
+    return false;
+  }
+  removeInputError({
+    input: passwordInput,
+    errorMessage: passwordErrorMessage,
+  });
+  return true;
+};
+
+passwordInput.addEventListener("focusout", (event) =>
+  validatePasswordInput(event.target.value)
+);
+
+const confirmPasswordInput = document.querySelector("#confirm-password");
+const confirmPasswordErrorMessage = document.querySelector(
+  "#confirm-password-error-message"
+);
+
+const validateConfirmPasswordInput = (confirmPassword) => {
+  if (confirmPassword === "" || !isPasswordValid(confirmPassword)) {
+    setInputError(
+      {
+        input: confirmPasswordInput,
+        errorMessage: confirmPasswordErrorMessage,
+      },
+      "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요."
+    );
+    return false;
+  }
+  if (passwordInput.value !== confirmPassword) {
+    setInputError(
+      {
+        input: confirmPasswordInput,
+        errorMessage: confirmPasswordErrorMessage,
+      },
+      "비밀번호가 일치하지 않아요."
+    );
+    return false;
+  }
+  removeInputError({
+    input: confirmPasswordInput,
+    errorMessage: confirmPasswordErrorMessage,
+  });
+  return true;
+};
+
+confirmPasswordInput.addEventListener("focusout", (event) =>
+  validateConfirmPasswordInput(event.target.value)
+);
+
+const passwordToggleButton = document.querySelector("#password-toggle");
+passwordToggleButton.addEventListener("click", () =>
+  togglePassword(passwordInput, passwordToggleButton)
+);
+
+const confirmPasswordToggleButton = document.querySelector(
+  "#confirm-password-toggle"
+);
+confirmPasswordToggleButton.addEventListener("click", () =>
+  togglePassword(confirmPasswordInput, confirmPasswordToggleButton)
+);
+
+const signForm = document.querySelector("#form");
+
+const submitForm = (event) => {
+  event.preventDefault();
+
+  const isEmailInputValid = validateEmailInput(emailInput.value);
+  const isPasswordInputValid = validatePasswordInput(passwordInput.value);
+  const isConfirmPasswordInputValid = validateConfirmPasswordInput(
+    confirmPasswordInput.value
+  );
+
+  if (
+    isEmailInputValid &&
+    isPasswordInputValid &&
+    isConfirmPasswordInputValid
+  ) {
+    location.href = "/folder";
+  }
+};
+
+signForm.addEventListener("submit", submitForm);

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,27 +6,38 @@ export const setInputError = (elements, message) => {
   elements.input.className += ` ${SIGN_INPUT_ERROR_CLASSNAME}`;
   elements.errorMessage.className += ` ${ERROR_MESSAGE_CLASSNAME}`;
   elements.errorMessage.textContent = message;
-}
+};
 
 export const removeInputError = (elements) => {
   elements.input.classList.remove(SIGN_INPUT_ERROR_CLASSNAME);
   elements.errorMessage.classList.remove(ERROR_MESSAGE_CLASSNAME);
   elements.errorMessage.textContent = "";
-}
+};
 
 export const isEmailValid = (email) => {
   return new RegExp(EMAIL_REGEX).test(email);
-}
+};
+
+export const isPasswordValid = (password) => {
+  const isEightLettersOrMore = password.length >= 8;
+  const hasNumberAndCharacter =
+    password.match(/[0-9]/g) && password.match(/[a-zA-Z]/gi);
+  return isEightLettersOrMore && hasNumberAndCharacter;
+};
 
 export const togglePassword = (input, toggleButton) => {
   if (input.getAttribute("type") === "password") {
     input.setAttribute("type", "text");
-    toggleButton.getElementsByTagName("img")[0].setAttribute("src", "./images/eye-on.svg");
+    toggleButton
+      .getElementsByTagName("img")[0]
+      .setAttribute("src", "./images/eye-on.svg");
     return;
   }
   input.setAttribute("type", "password");
-  toggleButton.getElementsByTagName("img")[0].setAttribute("src", "./images/eye-off.svg");
-}
+  toggleButton
+    .getElementsByTagName("img")[0]
+    .setAttribute("src", "./images/eye-off.svg");
+};
 
 export const TEST_USER = {
   email: "test@codeit.com",


### PR DESCRIPTION
### 기본
✔ [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?


✔ [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?


✔ [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?


✔ [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?


✔ [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?


✔ [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?


✔ [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?


✔ [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?


✔ [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화
✔ [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?


✔ [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


✔ [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?
