### PR TITLE
[조한빈] Week6

### DIFF
--- a/signin/index.js
+++ b/signin/index.js
@@ -49,15 +49,30 @@ function signInChecker(e) {
         return;
     }
 
-    if (EMAIL_INPUT.value === TEST_EMAIL && PASSWORD_INPUT.value === TEST_PW) {
-        location.assign('/folder');
-    } else {
-        const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
-        const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+    const SIGN_IN_REQUEST_BODY = {
+        email: EMAIL_INPUT.value,
+        password: PASSWORD_INPUT.value
+    };
 
-        loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
-        loginError(PASSWORD_INPUT, CHECK_YOUR_PW);
-    }
+    fetch('https://bootcamp-api.codeit.kr/api/sign-in', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify(SIGN_IN_REQUEST_BODY)
+    })
+        .then((response) => {
+            if (response.status === 200) {
+                location.assign('/folder');
+            } else {
+                const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
+                const CHECK_YOUR_PW = '비밀번호를 확인해 주세요.';
+        
+                loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
+                loginError(PASSWORD_INPUT, CHECK_YOUR_PW);        
+            }
+        })
+        .catch((error) => { console.log(error); });
 }
 
 EMAIL_INPUT.addEventListener('focusout', emailChecker);

--- a/signin/index.js
+++ b/signin/index.js
@@ -63,6 +63,7 @@ function signInChecker(e) {
     })
         .then((response) => {
             if (response.status === 200) {
+                EMAIL_INPUT.value = '';
                 location.assign('/folder');
             } else {
                 const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';

--- a/signup/index.js
+++ b/signup/index.js
@@ -65,22 +65,46 @@ function removeError(e) {
     }
 }
 
+// 이메일중복확인 리퀘스트 
+async function checkThisEmail() {   
+    try {
+        const CHECK_EMAIL_RESPONSE = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({email: EMAIL_INPUT.value})
+        });
+        
+        if (CHECK_EMAIL_RESPONSE.status === 409) return false;
+        else if (CHECK_EMAIL_RESPONSE.status === 200) return true;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
 // 회원가입 검사
-function signUpChecker(e) {
+async function signUpChecker(e) {
     if (e.type === 'keydown' && e.key !== 'Enter') {
         return;
     }
 
+    const EMAIL_NOT_IN_USE = await checkThisEmail();
     let pwCopy = PASSWORD_INPUT.value;
     pwCopy = [...pwCopy];
 
-    const INVALID_EMAIL = !EMAIL_INPUT.value || EMAIL_INPUT.validity.typeMismatch || EMAIL_INPUT.value === TEST_EMAIL;
+    const INVALID_EMAIL = !EMAIL_INPUT.value || EMAIL_INPUT.validity.typeMismatch;
     const INVALID_PW = PASSWORD_INPUT.value.length < 8 || Boolean(PASSWORD_INPUT.value / 1) || PASSWORD_INPUT.value / 1 === 0 || pwCopy.every(element => !(element / 1));
     const INVALID_PW_REPEAT = PASSWORD_INPUT.value !== PW_REPEAT_INPUT.value;
 
     if (INVALID_EMAIL) {
         const CHECK_YOUR_EMAIL = '이메일을 확인해 주세요.';
         loginError(EMAIL_INPUT, CHECK_YOUR_EMAIL);
+    } 
+
+    if (!EMAIL_NOT_IN_USE) {
+        const IS_BEING_USED = '이미 사용 중인 이메일입니다.';
+        loginError(EMAIL_INPUT, IS_BEING_USED);
     } 
     
     if (INVALID_PW) {
@@ -93,7 +117,8 @@ function signUpChecker(e) {
         loginError(PW_REPEAT_INPUT, CHECK_YOUR_PW);
     } 
 
-    if (!INVALID_EMAIL && !INVALID_PW && !INVALID_PW_REPEAT) {
+    if (!INVALID_EMAIL && !INVALID_PW && !INVALID_PW_REPEAT && EMAIL_NOT_IN_USE) {
+
         location.assign('/folder');
     }
 }   

--- a/signup/index.js
+++ b/signup/index.js
@@ -65,7 +65,25 @@ function removeError(e) {
     }
 }
 
-// 이메일중복확인 리퀘스트 
+// 회원가입 리퀘스트
+async function registerRequest() {
+    const REGISTER_BODY = {
+        email: EMAIL_INPUT.value,
+        password: PASSWORD_INPUT.value
+    };
+
+    const REGISTER_RESPONSE = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json'
+        },
+        body: JSON.stringify(REGISTER_BODY)
+    });
+    if (REGISTER_RESPONSE.status === 400) return false;
+    else if (REGISTER_RESPONSE.status === 200) return true;
+}
+
+// 이메일중복확인 후 회원가입 리퀘스트 
 async function checkThisEmail() {   
     try {
         const CHECK_EMAIL_RESPONSE = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
@@ -77,7 +95,7 @@ async function checkThisEmail() {
         });
         
         if (CHECK_EMAIL_RESPONSE.status === 409) return false;
-        else if (CHECK_EMAIL_RESPONSE.status === 200) return true;
+        else if (CHECK_EMAIL_RESPONSE.status === 200 && await registerRequest()) return true;
     } catch (error) {
         console.log(error);
     }
@@ -118,7 +136,7 @@ async function signUpChecker(e) {
     } 
 
     if (!INVALID_EMAIL && !INVALID_PW && !INVALID_PW_REPEAT && EMAIL_NOT_IN_USE) {
-
+        EMAIL_INPUT.value = '';
         location.assign('/folder');
     }
 }   

--- a/signup/index.js
+++ b/signup/index.js
@@ -72,13 +72,14 @@ async function registerRequest() {
         password: PASSWORD_INPUT.value
     };
 
-    const REGISTER_RESPONSE = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
+    const REGISTER_RESPONSE = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
         method: 'POST',
         headers: {
             'content-type': 'application/json'
         },
         body: JSON.stringify(REGISTER_BODY)
     });
+    
     if (REGISTER_RESPONSE.status === 400) return false;
     else if (REGISTER_RESPONSE.status === 200) return true;
 }


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본/로그인 페이지]
https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] [기본/회원가입 페이지]
이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] [기본/회원가입 페이지]
유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화
- [ ] [심화]
로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?
- [ ] [심화]
로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- 로그인, 회원가입 리퀘스트 처리 추가

## 스크린샷


## 멘토에게

- netlify 주소입니다: https://stirring-seahorse-43f42f.netlify.app/
- 가지마세요 멘토님
- 어찌어찌 함수는 만들었는데 너무 복잡해보여서.. 모듈을 만들거나 해보겠습니다. 어떡해야 할까요????
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
