### PR TITLE
[이서인] Week6

### DIFF
--- a/source/js/loginCheck.js
+++ b/source/js/loginCheck.js
@@ -14,16 +14,16 @@ async function login() {
       body: JSON.stringify({ email: emailValue, password: passwordValue }),
     });
     if (!result.ok) {
-      throw new Error(result.statusText);
+      console.error('Error: ' + result.status);
+      emailInput.classList.add('invalid');
+      emailError.innerHTML = '이메일을 확인해 주세요.';
+      passwordInput.classList.add('invalid');
+      passwordError.innerHTML = '비밀번호를 확인해 주세요.';
     } else {
       window.location.href = '../pages/folder.html';
     }
   } catch (error) {
-    console.log(error);
-    emailInput.classList.add('invalid');
-    emailError.innerHTML = '이메일을 확인해 주세요.';
-    passwordInput.classList.add('invalid');
-    passwordError.innerHTML = '비밀번호를 확인해 주세요.';
+    console.error(error);
   }
 }
 const signinForm = document.getElementById('signinForm');

--- a/source/js/loginCheck.js
+++ b/source/js/loginCheck.js
@@ -2,22 +2,25 @@ const emailInput = document.getElementById('email');
 const passwordInput = document.getElementById('password');
 
 //특정 이메일과 비밀번호 입력 시 페이지 이동
-function login() {
+async function login() {
   const emailValue = emailInput.value;
   const passwordValue = passwordInput.value;
-  const validEmail = 'test@codeit.com';
-  const validPassword = 'codeit101';
 
-  if (emailValue === validEmail && passwordValue === validPassword) {
-    window.location.href = './folder';
-  }
-
-  if (emailValue !== validEmail) {
+  //POST request 보내기
+  try {
+    const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-in', {
+      method: 'POST',
+      headers: { 'content-Type': 'application/json' },
+      body: JSON.stringify({ email: emailValue, password: passwordValue }),
+    });
+    window.location.href = '/folder';
+    if (!result.ok) {
+      throw new Error(result.statusText);
+    }
+  } catch (error) {
+    console.log(error);
     emailInput.classList.add('invalid');
     emailError.innerHTML = '이메일을 확인해 주세요.';
-  }
-
-  if (passwordValue !== validPassword) {
     passwordInput.classList.add('invalid');
     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
   }
@@ -30,6 +33,5 @@ signinForm.addEventListener('submit', function (e) {
 
 //로그인 버튼에 이벤트 리스너 등록
 const loginButton = document.getElementById('loginButton');
-loginButton.addEventListener('click', login);
 
 export default login;

--- a/source/js/loginCheck.js
+++ b/source/js/loginCheck.js
@@ -1,3 +1,5 @@
+import postFetcher from '../utils/postRequest.js';
+
 const emailInput = document.getElementById('email');
 const passwordInput = document.getElementById('password');
 
@@ -8,11 +10,7 @@ async function login() {
 
   //POST request 보내기
   try {
-    const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-in', {
-      method: 'POST',
-      headers: { 'content-Type': 'application/json' },
-      body: JSON.stringify({ email: emailValue, password: passwordValue }),
-    });
+    const result = await postFetcher('api/sign-in', 'email: emailValue, password: passwordValue');
     if (!result.ok) {
       console.error('Error: ' + result.status);
       emailInput.classList.add('invalid');

--- a/source/js/loginCheck.js
+++ b/source/js/loginCheck.js
@@ -13,9 +13,10 @@ async function login() {
       headers: { 'content-Type': 'application/json' },
       body: JSON.stringify({ email: emailValue, password: passwordValue }),
     });
-    window.location.href = '/folder';
     if (!result.ok) {
       throw new Error(result.statusText);
+    } else {
+      window.location.href = '../pages/folder.html';
     }
   } catch (error) {
     console.log(error);

--- a/source/js/signup.js
+++ b/source/js/signup.js
@@ -22,18 +22,6 @@ function handleEmailCheck() {
   emailError.innerHTML = '';
 }
 
-//사용 중인 email 에러 호출
-emailInput.addEventListener('focusout', usedEmailCheck);
-function usedEmailCheck() {
-  const emailValue = emailInput.value;
-  const usedEmail = 'test@codeit.com';
-
-  if (emailValue === usedEmail) {
-    emailInput.classList.add('invalid');
-    emailError.innerHTML = '이미 사용 중인 이메일입니다.';
-  }
-}
-
 //password 에러 메시지 호출
 passwordInput.addEventListener('focusout', handlePasswordCheck);
 function handlePasswordCheck() {

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -10,8 +10,8 @@ async function signupCheck() {
   const passwordCheckInput = document.getElementById('passwordCheck');
   const passwordValue = passwordInput.value;
   const passwordCheckValue = passwordCheckInput.value;
-  const checkEmail = validateEmail(emailInput.value);
-  const checkPassword = validatePassword(passwordInput.value);
+  const isEmail = validateEmail(emailInput.value);
+  const isPassword = validatePassword(passwordInput.value);
   const passwordCheckError = document.getElementById('passwordCheckError');
 
   //유효한 회원가입 형식 POST request 보내기
@@ -26,10 +26,10 @@ async function signupCheck() {
         'api/sign-up',
         'email: emailValue, password: passwordValue, passwordCheck: passwordCheckValue',
       );
-      if (!checkEmail) {
+      if (!isEmail) {
         emailInput.classList.add('invalid');
         emailError.innerHTML = '이메일을 확인해 주세요.';
-      } else if (!checkPassword) {
+      } else if (!isPassword) {
         passwordInput.classList.add('invalid');
         passwordError.innerHTML = '비밀번호를 확인해 주세요.';
       } else if (passwordValue !== passwordCheckValue) {

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -1,5 +1,6 @@
 import validateEmail from '../utils/emailValidate.js';
 import validatePassword from '../utils/passwordValidate.js';
+import postFetcher from '../utils/postRequest.js';
 
 //회원가입 실행 시 에러 메시지 호출 또는 페이지 이동
 async function signupCheck() {
@@ -15,21 +16,16 @@ async function signupCheck() {
 
   //유효한 회원가입 형식 POST request 보내기
   try {
-    const emailCheckResult = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
-      method: 'POST',
-      headers: { 'content-Type': 'application/json' },
-      body: JSON.stringify({ email: emailValue }),
-    });
+    const emailCheckResult = await postFetcher('api/check-email', 'email: emailValue');
     if (emailCheckResult.status === 409) {
       emailInput.classList.add('invalid');
       emailError.innerHTML = '중복된 이메일 입니다.';
       console.error('Error: ' + emailCheckResult.status);
     } else {
-      const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
-        method: 'POST',
-        headers: { 'content-Type': 'application/json' },
-        body: JSON.stringify({ email: emailValue, password: passwordValue, passwordCheck: passwordCheckValue }),
-      });
+      const result = await postFetcher(
+        'api/sign-up',
+        'email: emailValue, password: passwordValue, passwordCheck: passwordCheckValue',
+      );
       if (!checkEmail) {
         emailInput.classList.add('invalid');
         emailError.innerHTML = '이메일을 확인해 주세요.';

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -2,7 +2,7 @@ import validateEmail from '../utils/emailValidate.js';
 import validatePassword from '../utils/passwordValidate.js';
 
 //회원가입 실행 시 에러 메시지 호출 또는 페이지 이동
-function signupCheck() {
+async function signupCheck() {
   const emailInput = document.getElementById('email');
   const passwordInput = document.getElementById('password');
   const passwordCheckInput = document.getElementById('passwordCheck');
@@ -12,23 +12,19 @@ function signupCheck() {
   const checkPassword = validatePassword(passwordInput.value);
   const passwordCheckError = document.getElementById('passwordCheckError');
 
-  if (checkEmail && checkPassword) {
-    window.location.href = './folder';
-  }
-
-  if (!checkEmail) {
-    emailInput.classList.add('invalid');
-    emailError.innerHTML = '이메일을 확인해 주세요.';
-  }
-
-  if (!checkPassword) {
-    passwordInput.classList.add('invalid');
-    passwordError.innerHTML = '비밀번호를 확인해 주세요.';
-  }
-
-  if (passwordValue !== passwordCheckValue) {
-    passwordCheckInput.classList.add('invalid');
-    passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
+  //유효한 회원가입 형식 POST request 보내기
+  try {
+    const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
+      method: 'POST',
+      headers: { 'content-Type': 'application/json' },
+      body: JSON.stringify({ email: emailInput.value, password: passwordValue, passwordCheck: passwordCheckValue }),
+    });
+    window.location.href = '/folder';
+    if (!result.ok) {
+      throw new Error(result.statusText);
+    }
+  } catch (error) {
+    console.log(error);
   }
 }
 
@@ -38,8 +34,24 @@ signupForm.addEventListener('submit', function (e) {
   signupCheck();
 });
 
-//회원가입 버튼에 이벤트 리스너 등록
-const signupButton = document.getElementById('signupButton');
-signupButton.addEventListener('click', signupCheck);
-
 export default signupCheck;
+
+//   if (checkEmail && checkPassword) {
+//     window.location.href = './folder';
+//   }
+
+//   if (!checkEmail) {
+//     emailInput.classList.add('invalid');
+//     emailError.innerHTML = '이메일을 확인해 주세요.';
+//   }
+
+//   if (!checkPassword) {
+//     passwordInput.classList.add('invalid');
+//     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
+//   }
+
+//   if (passwordValue !== passwordCheckValue) {
+//     passwordCheckInput.classList.add('invalid');
+//     passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
+//   }
+// }

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -4,6 +4,7 @@ import validatePassword from '../utils/passwordValidate.js';
 //회원가입 실행 시 에러 메시지 호출 또는 페이지 이동
 async function signupCheck() {
   const emailInput = document.getElementById('email');
+  const emailValue = emailInput.value;
   const passwordInput = document.getElementById('password');
   const passwordCheckInput = document.getElementById('passwordCheck');
   const passwordValue = passwordInput.value;
@@ -14,32 +15,40 @@ async function signupCheck() {
 
   //유효한 회원가입 형식 POST request 보내기
   try {
-    const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
+    const emailCheckResult = await fetch('https://bootcamp-api.codeit.kr/api/check-email', {
       method: 'POST',
       headers: { 'content-Type': 'application/json' },
-      body: JSON.stringify({ email: emailInput.value, password: passwordValue, passwordCheck: passwordCheckValue }),
+      body: JSON.stringify({ email: emailValue }),
     });
-    if (emailInput.value === 'test@codeit.com') {
-      alert('중복된 이메일은 사용할 수 없습니다.');
-    } else if (!checkEmail) {
+    if (emailCheckResult.status === 409) {
       emailInput.classList.add('invalid');
-      emailError.innerHTML = '이메일을 확인해 주세요.';
-    } else if (!checkPassword) {
-      passwordInput.classList.add('invalid');
-      passwordError.innerHTML = '비밀번호를 확인해 주세요.';
-    } else if (passwordValue !== passwordCheckValue) {
-      passwordCheckInput.classList.add('invalid');
-      passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
-    } else if (!result.ok) {
-      throw new Error('회원가입에 실패했습니다.');
+      emailError.innerHTML = '중복된 이메일 입니다.';
+      throw new Error(emailCheckResult.statusText);
     } else {
-      window.location.href = '/folder';
+      const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
+        method: 'POST',
+        headers: { 'content-Type': 'application/json' },
+        body: JSON.stringify({ email: emailValue, password: passwordValue, passwordCheck: passwordCheckValue }),
+      });
+      if (!checkEmail) {
+        emailInput.classList.add('invalid');
+        emailError.innerHTML = '이메일을 확인해 주세요.';
+      } else if (!checkPassword) {
+        passwordInput.classList.add('invalid');
+        passwordError.innerHTML = '비밀번호를 확인해 주세요.';
+      } else if (passwordValue !== passwordCheckValue) {
+        passwordCheckInput.classList.add('invalid');
+        passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
+      } else if (!result.ok) {
+        throw new Error('회원가입에 실패했습니다.');
+      } else {
+        window.location.href = '../pages/folder.html';
+      }
     }
   } catch (error) {
     console.log(error);
   }
 }
-
 const signupForm = document.getElementById('signupForm');
 signupForm.addEventListener('submit', function (e) {
   e.preventDefault();

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -23,7 +23,7 @@ async function signupCheck() {
     if (emailCheckResult.status === 409) {
       emailInput.classList.add('invalid');
       emailError.innerHTML = '중복된 이메일 입니다.';
-      throw new Error(emailCheckResult.statusText);
+      console.error('Error: ' + emailCheckResult.status);
     } else {
       const result = await fetch('https://bootcamp-api.codeit.kr/api/sign-up', {
         method: 'POST',
@@ -40,13 +40,13 @@ async function signupCheck() {
         passwordCheckInput.classList.add('invalid');
         passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
       } else if (!result.ok) {
-        throw new Error('회원가입에 실패했습니다.');
+        console.error('회원가입에 실패했습니다.');
       } else {
         window.location.href = '../pages/folder.html';
       }
     }
   } catch (error) {
-    console.log(error);
+    console.error(error);
   }
 }
 const signupForm = document.getElementById('signupForm');

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -19,9 +19,21 @@ async function signupCheck() {
       headers: { 'content-Type': 'application/json' },
       body: JSON.stringify({ email: emailInput.value, password: passwordValue, passwordCheck: passwordCheckValue }),
     });
-    window.location.href = '/folder';
-    if (!result.ok) {
-      throw new Error(result.statusText);
+    if (emailInput.value === 'test@codeit.com') {
+      alert('중복된 이메일은 사용할 수 없습니다.');
+    } else if (!checkEmail) {
+      emailInput.classList.add('invalid');
+      emailError.innerHTML = '이메일을 확인해 주세요.';
+    } else if (!checkPassword) {
+      passwordInput.classList.add('invalid');
+      passwordError.innerHTML = '비밀번호를 확인해 주세요.';
+    } else if (passwordValue !== passwordCheckValue) {
+      passwordCheckInput.classList.add('invalid');
+      passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
+    } else if (!result.ok) {
+      throw new Error('회원가입에 실패했습니다.');
+    } else {
+      window.location.href = '/folder';
     }
   } catch (error) {
     console.log(error);
@@ -35,19 +47,3 @@ signupForm.addEventListener('submit', function (e) {
 });
 
 export default signupCheck;
-
-//   if (!checkEmail) {
-//     emailInput.classList.add('invalid');
-//     emailError.innerHTML = '이메일을 확인해 주세요.';
-//   }
-
-//   if (!checkPassword) {
-//     passwordInput.classList.add('invalid');
-//     passwordError.innerHTML = '비밀번호를 확인해 주세요.';
-//   }
-
-//   if (passwordValue !== passwordCheckValue) {
-//     passwordCheckInput.classList.add('invalid');
-//     passwordCheckError.innerHTML = '비밀번호가 일치하지 않아요.';
-//   }
-// }

--- a/source/js/signupCheck.js
+++ b/source/js/signupCheck.js
@@ -36,10 +36,6 @@ signupForm.addEventListener('submit', function (e) {
 
 export default signupCheck;
 
-//   if (checkEmail && checkPassword) {
-//     window.location.href = './folder';
-//   }
-
 //   if (!checkEmail) {
 //     emailInput.classList.add('invalid');
 //     emailError.innerHTML = '이메일을 확인해 주세요.';

--- a/source/pages/folder.html
+++ b/source/pages/folder.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html lang="ko">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>folder</title>
-  </head>
-  <body></body>
-</html>

--- a/source/pages/folder.html
+++ b/source/pages/folder.html
@@ -5,5 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>folder</title>
   </head>
-  <body></body>
+  <body>
+    <p>로그인</p>
+  </body>
 </html>

--- a/source/pages/folder.html
+++ b/source/pages/folder.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>folder</title>
+  </head>
+  <body></body>
+</html>

--- a/source/utils/postRequest.js
+++ b/source/utils/postRequest.js
@@ -1,0 +1,9 @@
+const postFetcher = (route, body) => {
+  return fetch(`https://bootcamp-api.codeit.kr/${route}`, {
+    method: 'POST',
+    headers: { 'content-Type': 'application/json' },
+    body: JSON.stringify({ body }),
+  });
+};
+
+export default postFetcher;


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본/로그인 페이지]
https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?

- [x] [기본/회원가입 페이지]
이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?

- [x] [기본/회원가입 페이지]
유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [ ] [심화]
로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?

- [ ] [심화]
로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- 로그인 POST 요청 추가
- 회원가입 POST 요청 추가

## 스크린샷

배포 링크: https://linkbraryproject.netlify.app/

## 멘토에게

- 회원가입 페이지 조건을 달 때 if~else문보다 switch문을 사용하는게 나을까요?
- netlify 배포를 하기 위해서 index.html 파일을 루트 폴더로 뺐습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
