### PR TITLE
[손승현] week 6

### DIFF
--- a/common.js
+++ b/common.js
@@ -1,10 +1,15 @@
-/* common variables and functions used for signin and signup pages */
+/* common functions used for signin and signup pages */
 
-export const toggleIcon = document.getElementById('eyeIcon');
-export const emailInput = document.getElementById('userEmail');
-export const passwordInput = document.getElementById('password');
-export const emailError = document.getElementById('emailError');
-export const passwordError = document.getElementById('passwordError');
+export const ERROR_MESSAGE = {
+    EMPTY_EMAIL_INPUT : '이메일을 입력해 주세요.',
+    EMPTY_PASSWORD_INPUT : '비밀번호를 입력해 주세요.',
+    INVALID_EMAIL : '올바른 이메일 주소가 아닙니다.',
+    INVALID_PASSWORD : '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.',
+    UNMATCH_PASSWORD : '비밀번호가 일치하지 않아요.',
+    ALREADY_USED_EMAIL : '이미 사용 중인 이메일입니다.',
+    CHECK_EMAIL :  '이메일을 확인해 주세요.',
+    CHECK_PASSWORD : '비밀번호를 확인해 주세요.',
+};
 
 export function isValidEmail(email) {
     // 간단한 이메일 형식 검사
@@ -22,12 +27,6 @@ export function hideErrorMessage(element) {
     element.textContent = '';
     element.style.display = 'none';
     element.previousElementSibling.style.borderColor = ''; // 테두리 색상 초기화
-}
-
-export function passwordToggle() {
-    const type_ = (passwordInput.type === 'password' ? 'text' : 'password');
-    passwordInput.type = type_;
-    toggleIcon.src = (type_ === 'password' ? 'img/eye-off.png' : 'img/eye-on.png');
 }
 
 /*비밀번호와 비밀번호 확인 인풋 칸에서 공통으로 쓸 수 있는 함수를 만들어보려하였으나 실패...*/

--- a/signin.js
+++ b/signin.js
@@ -1,66 +1,111 @@
 import {
+  ERROR_MESSAGE,
   isValidEmail,
   showErrorMessage,
   hideErrorMessage,
-  passwordToggle,
-
-  toggleIcon,
-  emailInput,
-  passwordInput,
-  emailError,
-  passwordError,
 } from './common.js';
 
+const toggleIcon = document.getElementById('eyeIcon');
+const emailInput = document.getElementById('userEmail');
+const passwordInput = document.getElementById('password');
+const emailError = document.getElementById('emailError');
+const passwordError = document.getElementById('passwordError');
 const loginButton = document.getElementById('signinButton');
+const baseUrl = 'https://bootcamp-api.codeit.kr';
 
+//눈 아이콘 토글 함수
+function passwordToggle() {
+  const inputType = (passwordInput.type === 'password' ? 'text' : 'password');
+  passwordInput.type = inputType;
+  toggleIcon.src = (inputType === 'password' ? 'img/eye-off.png' : 'img/eye-on.png');
+}
+
+//이메일 유효성 검사 함수
 function validateEmail() {
   const emailValue = emailInput.value.trim();
 
   if (emailValue === '') {
-    showErrorMessage(emailError, '이메일을 입력해 주세요.');
+    showErrorMessage(emailError, ERROR_MESSAGE.EMPTY_EMAIL_INPUT);
   } else if (!isValidEmail(emailValue)) {
-    showErrorMessage(emailError, '올바른 이메일 주소가 아닙니다.');
+    showErrorMessage(emailError, ERROR_MESSAGE.INVALID_EMAIL);
   } else {
     hideErrorMessage(emailError);
   }
 }
 
+//비밀번호 유효성 검사 함수
 function validatePassword() {
   const passwordValue = passwordInput.value.trim();
 
   if (passwordValue === '') {
-    showErrorMessage(passwordError, '비밀번호를 입력해 주세요.');
+    showErrorMessage(passwordError, ERROR_MESSAGE.EMPTY_PASSWORD_INPUT);
   } else {
     hideErrorMessage(passwordError);
   }
 }
 
+//엔터키 허용 함수
 function handleKeyPress(e) {
   if(e.key === 'Enter') {
       attemptLogin();
-      e.preventDefault(); //엔터키 누를 시 form을 form의 action 속성으로 전송하는 기본 동작 방지
+      //e.preventDefault(); //엔터키 누를 시 form을 form의 action 속성으로 전송하는 기본 동작 방지
   }
 }
 
-function attemptLogin(e) {
+//로그인 함수
+async function attemptLogin(e) {
+  e.preventDefault();
   validateEmail();
   validatePassword();
 
   const emailValue = emailInput.value.trim();
   const passwordValue = passwordInput.value.trim();
 
-  if (emailValue === 'test@codeit.com' && passwordValue === 'codeit101') {
+  const testUser = {
+    email : 'test@codeit.com',
+    password : 'sprint101',
+  };
+
+  try {
+    const response = await fetch(`${baseUrl}/api/sign-in`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(testUser), //js 객체를 외부로 내보내기 위해 json으로 변환(serialize)
+  });
+  
+  if (!response.ok) {
+    throw new Error(`An error occurred! HTTP Status: ${response.status}`);
+  }
+  const responseData = await response.json(); //json 형태의 응답이 deserialize되어 js 객체로 data에 저장됨
+  console.log('로그인 성공!', responseData);
+  window.localStorage.setItem('accessToken', responseData.data.accessToken);
+  window.location.href = 'folder.html';
+  } catch (error) {
+    console.error('로그인 실패 :', error);
+  }
+}
+ /* if (emailValue === 'test@codeit.com' && passwordValue === 'codeit101') {
     // 로그인 성공 시 페이지 이동
     console.log('로그인 성공');
-    e.preventDefault(); //submit 버튼 클릭 시 페이지가 새로고침되는 기본 동작 방지
+    //e.preventDefault(); //submit 버튼 클릭 시 페이지가 새로고침되는 기본 동작 방지
     window.location.href = 'folder.html';
   } else {
     if (emailValue !== 'test@codeit.com') {
-      showErrorMessage(emailError, '이메일을 확인해 주세요.');
+      showErrorMessage(emailError, ERROR_MESSAGE.CHECK_EMAIL);
     }
     if (passwordValue !== 'codeit101') {
-      showErrorMessage(passwordError, '비밀번호를 확인해 주세요.');
+      showErrorMessage(passwordError, ERROR_MESSAGE.CHECK_PASSWORD);
     }
+  }*/
+
+//토큰 확인 함수
+window.onload = function() {
+  const accessToken = localStorage.getItem('accessToken');
+
+  if(accessToken) {
+    window.location.href = 'folder.html';
   }
 }
 

--- a/signup.js
+++ b/signup.js
@@ -1,42 +1,79 @@
 import {
+    ERROR_MESSAGE,
     isValidEmail,
     showErrorMessage,
     hideErrorMessage,
-    passwordToggle,
-
-    toggleIcon,
-    emailInput,
-    passwordInput,
-    emailError,
-    passwordError,
 } from './common.js';
 
 
+const toggleIcon = document.getElementById('eyeIcon');
+const emailInput = document.getElementById('userEmail');
+const passwordInput = document.getElementById('password');
+const emailError = document.getElementById('emailError');
+const passwordError = document.getElementById('passwordError');
 const toggleIconRepeat = document.getElementById('eyeIconRepeat');
 const passwordRepeatInput = document.getElementById('passwordRepeat');
 const passwordRepeatError = document.getElementById('passwordRepeatError');
 const signupButton = document.getElementById('signupButton');
+const baseUrl = 'https://bootcamp-api.codeit.kr';
 
-function passwordRepeatToggle() {
-    const type_ = (passwordRepeatInput.type === 'password' ? 'text' : 'password');
-    passwordRepeatInput.type = type_;
-    toggleIconRepeat.src = (type_ === 'password' ? 'img/eye-off.png' : 'img/eye-on.png');
+//눈 아이콘 토글 함수
+function passwordToggle() {
+    const inputType = (passwordInput.type === 'password' ? 'text' : 'password');
+    passwordInput.type = inputType;
+    toggleIcon.src = (inputType === 'password' ? 'img/eye-off.png' : 'img/eye-on.png');
 }
 
-function validateEmail() {
+function passwordRepeatToggle() {
+    const inputType = (passwordRepeatInput.type === 'password' ? 'text' : 'password');
+    passwordRepeatInput.type = inputType;
+    toggleIconRepeat.src = (inputType === 'password' ? 'img/eye-off.png' : 'img/eye-on.png');
+}
+
+//이메일 중복 확인 함수
+async function checkEmail(email) {
+    try {
+        const response = await fetch(`${baseUrl}/api/check-email`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({email}), //email을 js 객체로 만들고, 만든 js 객체를 외부로 내보내기 위해 json으로 변환(serialize)
+    });
+    
+    if (!response.ok) {
+        throw new Error(`An error occurred! HTTP Status: ${response.status}`);
+    }
+    const responseData = await response.json(); //json 형태의 응답이 deserialize되어 js 객체로 data에 저장됨
+    return responseData.data.isUsableNickname;
+  } catch (error) {
+    console.error('이메일 중복 확인 실패 :', error);
+    return false;
+  }
+}
+
+//이메일 유효성 검사 함수 (+이메일 중복 확인 함수 호출)
+async function validateEmail() {
     const emailValue = emailInput.value.trim();
+    /*const testEmail = {
+        email: 'test@codeit.com',
+    };*/
+    const isEmailUsable = await checkEmail(emailValue);
 
     if (emailValue === '') {
-        showErrorMessage(emailError, '이메일을 입력해 주세요.');
-    } else if (emailValue === 'test@codeit.com') {
-        showErrorMessage(emailError, '이미 사용 중인 이메일입니다.');
+        showErrorMessage(emailError, ERROR_MESSAGE.EMPTY_EMAIL_INPUT);
+    } else if(!isEmailUsable) {
+        showErrorMessage(emailError, ERROR_MESSAGE.ALREADY_USED_EMAIL);
+    /*} else if (emailValue === 'test@codeit.com') {
+        showErrorMessage(emailError, ERROR_MESSAGE.ALREADY_USED_EMAIL);*/
     } else if (!isValidEmail(emailValue)) {
-        showErrorMessage(emailError, '올바른 이메일 주소가 아닙니다.');
+        showErrorMessage(emailError, ERROR_MESSAGE.INVALID_EMAIL);
     } else {
         hideErrorMessage(emailError);
     }
 }
 
+//비밀번호 유효성 검사 함수
 function isValidPassword(password) {
     const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
     return passwordRegex.test(password);
@@ -46,24 +83,26 @@ function validatePassword() {
     const passwordValue = passwordInput.value.trim();
 
     if (passwordValue === '' || !isValidPassword(passwordValue)) {
-        showErrorMessage(passwordError, '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.');
+        showErrorMessage(passwordError, ERROR_MESSAGE.INVALID_PASSWORD);
     } else {
         hideErrorMessage(passwordError);
     }
 }
 
+//비밀번호 확인 함수
 function checkRepeatPassword() {
     const passwordValue = passwordInput.value.trim();
     const passwordRepeatValue = passwordRepeatInput.value.trim();
 
     if (passwordValue !== passwordRepeatValue) {
-        showErrorMessage(passwordRepeatError, '비밀번호가 일치하지 않아요.');
+        showErrorMessage(passwordRepeatError, ERROR_MESSAGE.UNMATCH_PASSWORD);
     } else {
         hideErrorMessage(passwordRepeatError);
     }
 
 }
 
+//엔터키 허용 함수
 function handleKeyPress(e) {
     if(e.key === 'Enter') {
         attemptJoin();
@@ -71,26 +110,61 @@ function handleKeyPress(e) {
     }
 }
 
-function attemptJoin(e) {
+//회원가입 함수
+async function attemptJoin(e) {
+    const joinData = {
+        email: emailInput.value.trim(),
+        password: passwordInput.value.trim(),
+    };
+
+    e.preventDefault();
     validateEmail();
     validatePassword();
     checkRepeatPassword();
 
-    const emailValue = emailInput.value.trim();
-    const passwordValue = passwordInput.value.trim();
-    const passwordRepeatValue = passwordRepeatInput.value.trim();
+    try {
+        const response = await fetch(`${baseUrl}/api/sign-up`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(joinData), //email을 js 객체로 만들고, 만든 js 객체를 외부로 내보내기 위해 json으로 변환(serialize)
+        });
+        
+        if (!response.ok) {
+            throw new Error(`An error occurred! HTTP Status: ${response.status}`);
+        }
+        const responseData = await response.json(); //json 형태의 응답이 deserialize되어 js 객체로 data에 저장됨
+        console.log('회원가입 성공', responseData);
+        localStorage.setItem('accessToken', responseData.data.accessToken);
+        window.location.href = 'folder.html';
+    } catch(error) {
+        console.error('회원가입 실패 :', error);
+    }
 
-    if ((!emailError.textContent) && (!passwordError.textContent) && (!passwordRepeatError.textContent)) {
+    /*const noSignUpError = (!emailError.textContent) && (!passwordError.textContent) && (!passwordRepeatError.textContent);
+    const emailValue = emailInput.value.trim();
+
+    if (noSignUpError) {
       // 에러 메시지가 없다면 유효한 회원가입! 성공 시 페이지 이동
       if (emailValue === 'test@codeit.com') {
-        showErrorMessage(emailError, '이미 사용 중인 이메일입니다.');
+        showErrorMessage(emailError, ERROR_MESSAGE.ALREADY_USED_EMAIL);
       } else {
         console.log('회원가입 성공');
-        e.preventDefault(); //submit 버튼 클릭 시 페이지가 새로고침되는 기본 동작 방지
+        //e.preventDefault(); //submit 버튼 클릭 시 페이지가 새로고침되는 기본 동작 방지
         window.location.href = 'folder.html';
       }
-    }
+    }*/
 }
+
+//토큰 확인 함수
+window.onload = function() {
+    const accessToken = localStorage.getItem('accessToken');
+  
+    if(accessToken) {
+      window.location.href = 'folder.html';
+    }
+  }
 
 emailInput.addEventListener('focusout', validateEmail);
 passwordInput.addEventListener('focusout', validatePassword);


### PR DESCRIPTION
## 요구사항

### 기본
[기본/로그인 페이지]
- [x] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?

[기본/회원가입 페이지]
- [x] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?

[기본/회원가입 페이지]
- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화
[심화]
- [x] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?

[심화]
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항
- 5주차 피드백 반영
- 6주차 기능 구현
- 배포 주소 : https://linason-esc-linkbrary-week6.netlify.app/

## 스크린샷

## 멘토에게
- 저번주랑 이번주에 리액트 학습과 타 프로젝트 기획에 정신이 없어서 6주차 제출을 새까맣게 잊어버렸었습니다...... @_ㅠ 그럼에도 거두어주셔서 너무 죄송하고 또 감사합니다🥲
- 그동안 꼼꼼하게 리뷰해주셔서 정말 감사했습니다!! 앞으로 부트캠프 이어나가면서도 멘토님은 절대 못잊을 것 같아요..🥹
 
- 마지막인만큼 매운 피드백 부탁드리겠습니다!!
1. 로그인이나 회원가입 페이지 이동 시 토큰 여부에 따라 폴더페이지를 띄울 때 도저히 감이 안잡혀서 이것저것 많이 찾아보다가  window.onload를 써서 구현하였는데, 혹시 이게 안 좋은 방법은 아니겠죠..?
2. async await을 적재적소에 잘 사용하였는지 궁금합니다!