### PR TITLE
[김수환] week15

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,4 @@
 import "./globals.css";
-import Script from "next/script";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -10,8 +10,24 @@ const Signin = () => {
   const [isRender, setIsRender] = useState(false);
   const router = useRouter();
   useEffect(() => {
+    let shouldRedirect = false;
     if (window.localStorage.length) {
-      setIsRender(false);
+      let key;
+      let value;
+      for (let i = 0; i < localStorage.length; i++) {
+        key = localStorage.key(i);
+        if (key) {
+          value = localStorage.getItem(key);
+        }
+        if (key === value) {
+          shouldRedirect = true;
+          break;
+        }
+      }
+    } else {
+      shouldRedirect = false;
+    }
+    if (shouldRedirect) {
       router.push("/folder");
     } else {
       setIsRender(true);

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -13,13 +13,10 @@ const Signin = () => {
     let shouldRedirect = false;
     if (window.localStorage.length) {
       let key;
-      let value;
+
       for (let i = 0; i < localStorage.length; i++) {
         key = localStorage.key(i);
-        if (key) {
-          value = localStorage.getItem(key);
-        }
-        if (key === value) {
+        if (key === "accessToken") {
           shouldRedirect = true;
           break;
         }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -13,13 +13,9 @@ const Signup = () => {
     let shouldRedirect = false;
     if (window.localStorage.length) {
       let key;
-      let value;
       for (let i = 0; i < localStorage.length; i++) {
         key = localStorage.key(i);
-        if (key) {
-          value = localStorage.getItem(key);
-        }
-        if (key === value) {
+        if (key === "accessToken") {
           shouldRedirect = true;
           break;
         }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -10,8 +10,24 @@ const Signup = () => {
   const [isRender, setIsRender] = useState(false);
   const router = useRouter();
   useEffect(() => {
+    let shouldRedirect = false;
     if (window.localStorage.length) {
-      setIsRender(false);
+      let key;
+      let value;
+      for (let i = 0; i < localStorage.length; i++) {
+        key = localStorage.key(i);
+        if (key) {
+          value = localStorage.getItem(key);
+        }
+        if (key === value) {
+          shouldRedirect = true;
+          break;
+        }
+      }
+    } else {
+      shouldRedirect = false;
+    }
+    if (shouldRedirect) {
       router.push("/folder");
     } else {
       setIsRender(true);

--- a/components/SigninForm.tsx
+++ b/components/SigninForm.tsx
@@ -74,10 +74,7 @@ const SigninForm = () => {
   const onSubmit = async (data: FieldValues) => {
     const result = await postLoginData(data);
     if (result.data) {
-      tokenSetting.saveToLocalStorage(
-        result.data.accessToken,
-        result.data.accessToken
-      );
+      tokenSetting.saveToLocalStorage("accessToken", result.data.accessToken);
       router.push("/folder");
     } else {
       handleEmailBlur(EMAIL_VALIDATION_TEXT.fail);

--- a/components/SigninForm.tsx
+++ b/components/SigninForm.tsx
@@ -74,7 +74,10 @@ const SigninForm = () => {
   const onSubmit = async (data: FieldValues) => {
     const result = await postLoginData(data);
     if (result.data) {
-      tokenSetting.saveToLocalStorage(data.email, result.data.accessToken);
+      tokenSetting.saveToLocalStorage(
+        result.data.accessToken,
+        result.data.accessToken
+      );
       router.push("/folder");
     } else {
       handleEmailBlur(EMAIL_VALIDATION_TEXT.fail);

--- a/components/SigninForm.tsx
+++ b/components/SigninForm.tsx
@@ -75,7 +75,7 @@ const SigninForm = () => {
     const result = await postLoginData(data);
     if (result.data) {
       tokenSetting.saveToLocalStorage(data.email, result.data.accessToken);
-      router.push("/");
+      router.push("/folder");
     } else {
       handleEmailBlur(EMAIL_VALIDATION_TEXT.fail);
       handlePasswordBlur(PASSWORD_VALIDATION_TEXT.fail);

--- a/components/SignupForm.tsx
+++ b/components/SignupForm.tsx
@@ -81,7 +81,10 @@ const SignupForm = () => {
   const onSubmit = async (data: FieldValues) => {
     const result = await postSignupData(data);
     if (result.data) {
-      tokenSetting.saveToLocalStorage(data.email, result.data.accessToken);
+      tokenSetting.saveToLocalStorage(
+        result.data.accessToken,
+        result.data.accessToken
+      );
       router.push("/folder");
     }
   };

--- a/components/SignupForm.tsx
+++ b/components/SignupForm.tsx
@@ -81,10 +81,7 @@ const SignupForm = () => {
   const onSubmit = async (data: FieldValues) => {
     const result = await postSignupData(data);
     if (result.data) {
-      tokenSetting.saveToLocalStorage(
-        result.data.accessToken,
-        result.data.accessToken
-      );
+      tokenSetting.saveToLocalStorage("accessToken", result.data.accessToken);
       router.push("/folder");
     }
   };


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [로그인페이지] 회원 가입하기”를 클릭하면 ‘/signup’ 페이지로 이동하나요?
- [x] [로그인페이지] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “비밀번호를 입력해 주세요.”가 보이나요?
- [x] [로그인페이지]이메일 input에서 focus out 할 때, 값이 없을 경우 아래에 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [로그인페이지]  이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 아래에 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [로그인페이지]  비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [로그인페이지] 로그인 실패하는 경우, 이메일 input 아래에 “이메일을 확인해주세요.”, 비밀번호 input 아래에 “비밀번호를 확인해주세요.” 에러 메세지가 보이나요?
- [x] [로그인페이지]  로그인 버튼 클릭 또는 Enter키 입력으로 로그인 실행 되나요?
- [x] [로그인페이지] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] [회원가입 페이지] “회원 가입하기”를 클릭하면 ‘/signin’ 페이지로 이동하나요?
- [x] [회원가입 페이지] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “영문, 숫자를 조합해 8자 이상 입력해 주세요. ”비밀번호 확인 input에 placeholder는 “비밀번호와 일치하는 값을 입력해 주세요.”가 보이나요?
- [x] [회원가입 페이지] 이메일 input에서 focus out 할 때, 값이 없을 경우 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않아요.” 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지가 보이나요?
- [x] [회원가입 페이지] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 실행 되나요?
- [x] [회원가입 페이지] 이메일 중복 확인은 “/api/check-email” POST 요청해서 확인 할 수 있나요?
- [x] [회원가입 페이지] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] [로그인, 회원가입 페이지 공통] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지나요?
- [x] [로그인, 회원가입 페이지 공통] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [로그인, 회원가입 페이지 공통] 소셜 로그인에 구글 아이콘 클릭시 ‘https://www.google.com’, 카카오 아이콘 클릭시 ‘https://www.kakaocorp.com/page’로 이동하나요?
- [x] [로그인, 회원가입 페이지 공통] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장하나요?
- [x] [로그인, 회원가입 페이지 공통] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 ‘/folder’ 페이지로 이동하나요?

### 심화

- [x] [심화 체크리스트] 로그인, 회원가입 기능에 react-hook-form을 활용했나요?

## 주요 변경사항

- 최대한 use client를 훅이 필요한 부분에만 사용하려고 노력하여 다른 페이지들을 리팩토링 했습니다.
- react-hook-form을 활용했습니다.

## 멘토에게
- https://4-weekly-mission-341t-myrbq3m9n-soohwan93s-projects.vercel.app/signin 로그인 페이지 링크입니다~ 회원가입은 signup으로 변경하시면 됩니다! 다른 페이지들은 /shared, /folder, / 등등이 있습니다
- folder 페이지의 경우 리팩토링이 좀 어려워서 건드리지 못했는데 use client의 범위를 더 좁힐 수 있는 방법이 있는지 한 번 봐주셨으면 좋겠습니다~
- react-hook-form을 사용하긴 했는데 기존의 코드를 완전히 뒤엎기는 어려웠는데요. onBlur와 같은 이벤트를 함께 사용 할 경우 에러를 따로 생성해줘야 했습니다. 혹시 react-hook-form을 더 활용하여 코드를 더 간결히 할 수 있는 부분이 있다면 말씀해주시면 좋겠습니다!
- 제가 week14브랜치의 conflict 때문에 merge가 늦어져서 week15를 미리 pr 올리지 못해 이번 commit 5개에 대한 것들 말고 이전에 내용(14주차)도 봐주셨으면 좋겠습니다!
