### PR TITLE
[김경주] Week15

### DIFF
--- a/components/folder/FolderCardList.tsx
+++ b/components/folder/FolderCardList.tsx
@@ -69,7 +69,11 @@ function FolderCardList({ folders }: FolderCardListProps) {
   }, []);
 
   useEffect(() => {
-    const filteredData = searchTerm ? originalData.filter((card) => card.url.includes(searchTerm) || card.title?.toLowerCase().includes(searchTerm.toLowerCase()) || card.description?.toLowerCase().includes(searchTerm.toLowerCase())) : originalData;
+    const filteredData = searchTerm
+      ? originalData.filter(
+          (card) => card.url.includes(searchTerm) || card.title?.toLowerCase().includes(searchTerm.toLowerCase()) || card.description?.toLowerCase().includes(searchTerm.toLowerCase())
+        )
+      : originalData;
     setLinkData(filteredData);
   }, [searchTerm, originalData]);
 

--- a/components/sign/SigninForm.tsx
+++ b/components/sign/SigninForm.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
 import { useRouter } from "next/router";
 import { isValidEmail } from "./sign";
-import styles from "@/styles/LoginForm.module.css";
+import styles from "@/styles/SigninForm.module.css";
 
-interface LoginFormData {
+interface SigninFormData {
   email: string;
   password: string;
 }
 
-function LoginForm() {
-  const [formData, setFormData] = useState<LoginFormData>({ email: "", password: "" });
+function SignupForm() {
+  const [formData, setFormData] = useState<SigninFormData>({ email: "", password: "" });
   const [emailError, setEmailError] = useState<string>("");
   const [passwordError, setPasswordError] = useState<string>("");
   const [emailFocus, setEmailFocus] = useState<boolean>(false);
@@ -26,7 +26,8 @@ function LoginForm() {
     if (!formData.email) {
       setEmailError("이메일을 입력해 주세요.");
       return false;
-    } else if (!isValidEmail(formData.email)) {
+    }
+    if (!isValidEmail(formData.email)) {
       setEmailError("올바른 이메일 주소가 아닙니다.");
       return false;
     }
@@ -47,18 +48,8 @@ function LoginForm() {
     setEmailFocus(true);
   }
 
-  function handleEmailBlur() {
-    handleEmail();
-    setEmailFocus(false);
-  }
-
   function handlePasswordFocus() {
     setPasswordFocus(true);
-  }
-
-  function handlePasswordBlur() {
-    handlePassword();
-    setPasswordFocus(false);
   }
 
   function togglePasswordVisibility() {
@@ -106,17 +97,39 @@ function LoginForm() {
         <label htmlFor="email" className={styles.signLabel}>
           이메일
         </label>
-        <input id="email" name="email" type="email" className={`${styles.signInput} ${emailError && !emailFocus ? styles.signInputError : ""}`} value={formData.email} onChange={handleChange} onFocus={handleEmailFocus} onBlur={handleEmailBlur} />
+        <input
+          id="email"
+          name="email"
+          type="email"
+          placeholder="이메일을 입력해주세요."
+          className={`${styles.signInput} ${emailError ? styles.signInputError : ""}`}
+          value={formData.email}
+          onChange={handleChange}
+          onFocus={handleEmailFocus}
+          onBlur={handleEmail}
+        />
         {emailError && <div className={styles.errorMessage}>{emailError}</div>}
       </div>
       <div className={styles.passwordContainer}>
         <label htmlFor="password" className={styles.signLabel}>
           비밀번호
         </label>
-        <input id="password" name="password" type={isPasswordVisible ? "text" : "password"} className={`${styles.signInput} ${passwordError && !passwordFocus ? styles.signInputError : ""}`} value={formData.password} onChange={handleChange} onFocus={handlePasswordFocus} onBlur={handlePasswordBlur} />
-        <button className={styles.eyeButton} type="button" onClick={togglePasswordVisibility}>
-          {isPasswordVisible ? <img src="/img/eye-on.svg" alt="Hide password" /> : <img src="/img/eye-off.svg" alt="Show password" />}
-        </button>
+        <div className={styles.passwordInput}>
+          <input
+            id="password"
+            name="password"
+            type={isPasswordVisible ? "text" : "password"}
+            placeholder="비밀번호를 입력해 주세요."
+            className={`${styles.signInput} ${passwordError ? styles.signInputError : ""}`}
+            value={formData.password}
+            onChange={handleChange}
+            onFocus={handlePasswordFocus}
+            onBlur={handlePassword}
+          />
+          <button className={styles.eyeButton} type="button" onClick={togglePasswordVisibility}>
+            {isPasswordVisible ? <img src="/img/eye-on.svg" alt="Hide password" /> : <img src="/img/eye-off.svg" alt="Show password" />}
+          </button>
+        </div>
         {passwordError && <div className={styles.errorMessage}>{passwordError}</div>}
       </div>
       <button className={styles.buttonLogin} type="submit">
@@ -126,4 +139,4 @@ function LoginForm() {
   );
 }
 
-export default LoginForm;
+export default SignupForm;

--- a/components/sign/SigninForm.tsx
+++ b/components/sign/SigninForm.tsx
@@ -8,7 +8,7 @@ interface SigninFormData {
   password: string;
 }
 
-function SignupForm() {
+function SigninForm() {
   const [formData, setFormData] = useState<SigninFormData>({ email: "", password: "" });
   const [emailError, setEmailError] = useState<string>("");
   const [passwordError, setPasswordError] = useState<string>("");
@@ -139,4 +139,4 @@ function SignupForm() {
   );
 }
 
-export default SignupForm;
+export default SigninForm;

--- a/components/sign/SignupForm.tsx
+++ b/components/sign/SignupForm.tsx
@@ -35,8 +35,25 @@ function SignupForm() {
       setEmailError("올바른 이메일 주소가 아닙니다.");
       return false;
     }
-    setEmailError("");
+    checkEmail(formData.email);
     return true;
+  }
+
+  async function checkEmail(email: string) {
+    try {
+      const response = await fetch("https://bootcamp-api.codeit.kr/api/check-email", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+      if (response.status === 409) {
+        setEmailError("이미 사용 중인 이메일입니다.");
+      }
+    } catch (error) {
+      console.error(error);
+    }
   }
 
   function handlePassword() {
@@ -84,6 +101,37 @@ function SignupForm() {
 
     if (!isEmailValid || !isPasswordValid) {
       return;
+    }
+
+    try {
+      const response = await fetch("https://bootcamp-api.codeit.kr/api/sign-up", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: formData.email,
+          password: formData.password,
+        }),
+      });
+
+      const data = await response.json();
+      if (response.ok) {
+        localStorage.setItem("accessToken", data.accessToken);
+        router.push("/folder");
+      } else {
+        if (data.error && data.error.includes("Email")) {
+          setEmailError("올바른 이메일 주소가 아닙니다.");
+        }
+        if (data.error && data.error.includes("Password")) {
+          setPasswordError("비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.");
+        }
+        if (data.error && data.error.includes("PasswordConfirm")) {
+          setPasswordConfirmError("비밀번호가 일치하지 않아요.");
+        }
+      }
+    } catch (error) {
+      console.error(error);
     }
   };
 

--- a/components/sign/SignupForm.tsx
+++ b/components/sign/SignupForm.tsx
@@ -36,6 +36,7 @@ function SignupForm() {
       return false;
     }
     checkEmail(formData.email);
+    setEmailError("");
     return true;
   }
 

--- a/components/sign/SignupForm.tsx
+++ b/components/sign/SignupForm.tsx
@@ -1,0 +1,160 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { isValidEmail, isValidPassword } from "./sign";
+import styles from "@/styles/SignupForm.module.css";
+
+interface SignupFormData {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+function SignupForm() {
+  const [formData, setFormData] = useState<SignupFormData>({ email: "", password: "", passwordConfirm: "" });
+  const [emailError, setEmailError] = useState<string>("");
+  const [passwordError, setPasswordError] = useState<string>("");
+  const [passwordConfirmError, setPasswordConfirmError] = useState<string>("");
+  const [emailFocus, setEmailFocus] = useState<boolean>(false);
+  const [passwordFocus, setPasswordFocus] = useState<boolean>(false);
+  const [passwordConFirmFocus, setPasswordConFirmFocus] = useState<boolean>(false);
+  const [isPasswordVisible, setIsPasswordVisible] = useState<boolean>(false);
+  const [isPasswordConfirmVisible, setIsPasswordConfirmVisible] = useState<boolean>(false);
+  const router = useRouter();
+
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const { name, value } = event.target;
+    setFormData({ ...formData, [name]: value });
+  }
+
+  function handleEmail() {
+    if (!formData.email) {
+      setEmailError("이메일을 입력해 주세요.");
+      return false;
+    }
+    if (!isValidEmail(formData.email)) {
+      setEmailError("올바른 이메일 주소가 아닙니다.");
+      return false;
+    }
+    setEmailError("");
+    return true;
+  }
+
+  function handlePassword() {
+    if (!isValidPassword(formData.password)) {
+      setPasswordError("비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.");
+      return false;
+    }
+    setPasswordError("");
+    return true;
+  }
+
+  const handlePasswordConfirm = () => {
+    if (formData.password !== formData.passwordConfirm) {
+      setPasswordConfirmError("비밀번호가 일치하지 않아요.");
+      return false;
+    }
+    setPasswordConfirmError("");
+    return true;
+  };
+
+  function handleEmailFocus() {
+    setEmailFocus(true);
+  }
+
+  function handlePasswordFocus() {
+    setPasswordFocus(true);
+  }
+
+  function handlePasswordConfirmFocus() {
+    setPasswordConFirmFocus(true);
+  }
+
+  function togglePasswordVisibility() {
+    setIsPasswordVisible(!isPasswordVisible);
+  }
+
+  function togglePasswordConfirmVisibility() {
+    setIsPasswordConfirmVisible(!isPasswordConfirmVisible);
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const isEmailValid = handleEmail();
+    const isPasswordValid = handlePassword();
+
+    if (!isEmailValid || !isPasswordValid) {
+      return;
+    }
+  };
+
+  return (
+    <form className={styles.loginForm} onSubmit={handleSubmit}>
+      <div className={styles.emailContainer}>
+        <label htmlFor="email" className={styles.signLabel}>
+          이메일
+        </label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          placeholder="이메일을 입력해주세요."
+          className={`${styles.signInput} ${emailError ? styles.signInputError : ""}`}
+          value={formData.email}
+          onChange={handleChange}
+          onFocus={handleEmailFocus}
+          onBlur={handleEmail}
+        />
+        {emailError && <div className={styles.errorMessage}>{emailError}</div>}
+      </div>
+      <div className={styles.passwordContainer}>
+        <label htmlFor="password" className={styles.signLabel}>
+          비밀번호
+        </label>
+        <div className={styles.passwordInput}>
+          <input
+            id="password"
+            name="password"
+            type={isPasswordVisible ? "text" : "password"}
+            placeholder="비밀번호를 입력해 주세요."
+            className={`${styles.signInput} ${passwordError ? styles.signInputError : ""}`}
+            value={formData.password}
+            onChange={handleChange}
+            onFocus={handlePasswordFocus}
+            onBlur={handlePassword}
+          />
+          <button className={styles.eyeButton} type="button" onClick={togglePasswordVisibility}>
+            {isPasswordVisible ? <img src="/img/eye-on.svg" alt="Hide password" /> : <img src="/img/eye-off.svg" alt="Show password" />}
+          </button>
+        </div>
+        {passwordError && <div className={styles.errorMessage}>{passwordError}</div>}
+      </div>
+      <div className={styles.passwordContainer}>
+        <label htmlFor="passwordConfirm" className={styles.signLabel}>
+          비밀번호 확인
+        </label>
+        <div className={styles.passwordInput}>
+          <input
+            id="passwordConfirm"
+            name="passwordConfirm"
+            type={isPasswordConfirmVisible ? "text" : "password"}
+            placeholder="비밀번호와 일치하는 값을 입력해 주세요."
+            className={`${styles.signInput} ${passwordConfirmError ? styles.signInputError : ""}`}
+            value={formData.passwordConfirm}
+            onChange={handleChange}
+            onFocus={handlePasswordConfirmFocus}
+            onBlur={handlePasswordConfirm}
+          />
+          <button className={styles.eyeButton} type="button" onClick={togglePasswordConfirmVisibility}>
+            {isPasswordConfirmVisible ? <img src="/img/eye-on.svg" alt="Hide password confirm" /> : <img src="/img/eye-off.svg" alt="Show password confirm" />}
+          </button>
+        </div>
+        {passwordConfirmError && <div className={styles.errorMessage}>{passwordConfirmError}</div>}
+      </div>
+      <button className={styles.buttonLogin} type="submit">
+        회원가입
+      </button>
+    </form>
+  );
+}
+
+export default SignupForm;

--- a/components/sign/SignupHeader.tsx
+++ b/components/sign/SignupHeader.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import styles from "@/styles/SignupHeader.module.css";
+
+function SigninHeader() {
+  return (
+    <header className={styles.header}>
+      <Link href="/">
+        <img className={styles.headerLogo} src="img/logo.svg" alt="홈 연결 로고" />
+      </Link>
+      <p className={styles.headerMessage}>
+        이미 회원이신가요?
+        <Link href="/signin" className={styles.headerSigninLink}>
+          로그인 하기
+        </Link>
+      </p>
+    </header>
+  );
+}
+
+export default SigninHeader;

--- a/components/sign/SocialSignup.tsx
+++ b/components/sign/SocialSignup.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import styles from "@/styles/SocialLogin.module.css";
+
+function SocialLogin() {
+  return (
+    <div className={styles.socialLoginContainer}>
+      <div className={styles.socialLogin}>
+        <span className={styles.socialMessage}>다른 방식으로 가입하기</span>
+        <div className={styles.socialLink}>
+          <Link className={styles.googleImg} href="https://www.google.com">
+            <img src="/img/google.png" alt="google 로그인" />
+          </Link>
+          <Link className={styles.kakaoImg} href="https://www.kakaocorp.com/page/">
+            <img src="/img/kakao.svg" alt="kakao 로그인" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+export default SocialLogin;

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,5 +1,5 @@
 import SigninHeader from "@/components/sign/SigninHeader";
-import SignupForm from "@/components/sign/SigninForm";
+import SigninForm from "@/components/sign/SigninForm";
 import SocialLogin from "@/components/sign/SocialLogin";
 import styles from "@/styles/Signin.module.css";
 
@@ -7,7 +7,7 @@ function Signin() {
   return (
     <div className={styles.signinContainer}>
       <SigninHeader />
-      <SignupForm />
+      <SigninForm />
       <SocialLogin />
     </div>
   );

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,5 +1,5 @@
 import SigninHeader from "@/components/sign/SigninHeader";
-import LoginForm from "@/components/sign/LoginForm";
+import SignupForm from "@/components/sign/SigninForm";
 import SocialLogin from "@/components/sign/SocialLogin";
 import styles from "@/styles/Signin.module.css";
 
@@ -7,7 +7,7 @@ function Signin() {
   return (
     <div className={styles.signinContainer}>
       <SigninHeader />
-      <LoginForm />
+      <SignupForm />
       <SocialLogin />
     </div>
   );

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,0 +1,16 @@
+import SignupHeader from "@/components/sign/SignupHeader";
+import SignupForm from "@/components/sign/SignupForm";
+import SocialSignup from "@/components/sign/SocialSignup";
+import styles from "@/styles/Signup.module.css";
+
+function Signup() {
+  return (
+    <div className={styles.signupContainer}>
+      <SignupHeader />
+      <SignupForm />
+      <SocialSignup />
+    </div>
+  );
+}
+
+export default Signup;

--- a/styles/SigninForm.module.css
+++ b/styles/SigninForm.module.css
@@ -16,10 +16,8 @@
   margin-top: 2.4rem;
 }
 
-.passwordInputContainer {
+.passwordInput {
   position: relative;
-  display: flex;
-  align-items: center; /* 중앙 정렬 */
 }
 
 .signLabel {
@@ -30,6 +28,7 @@
 
 .signInput {
   display: flex;
+  width: 100%;
   padding: 1.8rem 1.5rem;
   justify-content: center;
   align-items: center;
@@ -84,4 +83,5 @@
   color: var(--Grey-Light);
   font-size: 1.8rem;
   font-weight: 600;
+  cursor: pointer;
 }

--- a/styles/Signup.module.css
+++ b/styles/Signup.module.css
@@ -1,0 +1,8 @@
+.signupContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  flex-direction: column;
+  background-color: var(--Linkbrary-bg);
+}

--- a/styles/SignupForm.module.css
+++ b/styles/SignupForm.module.css
@@ -1,0 +1,87 @@
+.loginForm {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.emailContainer,
+.passwordContainer {
+  display: flex;
+  flex-direction: column;
+  width: 40rem;
+}
+
+.passwordContainer {
+  position: relative;
+  margin-top: 2.4rem;
+}
+
+.passwordInput {
+  position: relative;
+}
+
+.signLabel {
+  margin-bottom: 1.2rem;
+  color: var(--Black);
+  font-size: 1.4rem;
+}
+
+.signInput {
+  display: flex;
+  width: 100%;
+  padding: 1.8rem 1.5rem;
+  justify-content: center;
+  align-items: center;
+  border-radius: 0.8rem;
+  border: 0.1rem solid var(--Linkbrary-gray20);
+  background: var(--Linkbrary-white);
+  font-size: 1.6rem;
+}
+
+.signInput:focus {
+  outline: 0.1rem solid var(--Linkbrary-primary-color);
+}
+
+.passwordToggle {
+  position: relative;
+}
+
+.errorMessage {
+  margin-top: 0.6rem;
+  font-size: 1.4rem;
+  line-height: 1.7rem;
+  color: var(--Linkbrary-red);
+}
+
+.signInputError {
+  border: 0.1rem solid var(--Linkbrary-red);
+}
+
+.eyeButton {
+  position: absolute;
+  top: 50%;
+  right: 1.5rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  border: none;
+  cursor: pointer;
+  transform: translateY(-50%);
+}
+
+.buttonLogin {
+  display: flex;
+  width: 40rem;
+  padding: 1.6rem 2rem;
+  margin-top: 3rem;
+  margin-bottom: 3.2rem;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  border: none;
+  border-radius: 0.8rem;
+  background: var(--gra-purpleblue-to-skyblue);
+  color: var(--Grey-Light);
+  font-size: 1.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/styles/SignupHeader.module.css
+++ b/styles/SignupHeader.module.css
@@ -1,0 +1,26 @@
+.header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 3rem;
+  gap: 1.6rem;
+}
+
+.headerMessage {
+  display: flex;
+  gap: 0.8rem;
+  color: var(--Black);
+  font-size: 1.6rem;
+  line-height: 2.4rem;
+}
+
+.headerSigninLink {
+  color: var(--Linkbrary-primary-color);
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: normal;
+}
+
+.headerLogo {
+  height: 3.8rem;
+}


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본] 회원 가입하기”를 클릭하면 ‘/signup’ 페이지로 이동하나요?
- [x] [기본] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “비밀번호를 입력해 주세요.”가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 아래에 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 아래에 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [기본] 비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본] 로그인 실패하는 경우, 이메일 input 아래에 “이메일을 확인해주세요.”, 비밀번호 input 아래에 “비밀번호를 확인해주세요.” 에러 메세지가 보이나요?
- [x] [기본] 로그인 버튼 클릭 또는 Enter키 입력으로 로그인 실행 되나요?
- [x] [기본] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “[test@codeit.com](mailto:test@codeit.com)”, “password”: “sprint101” } POST 요청해서 성공 응답을 받으면 “/folder”로 이동하나요?

- [x] [기본] “회원 가입하기”를 클릭하면 ‘/signin’ 페이지로 이동하나요?
- [x] [기본] 이메일 input에 placeholder는 “이메일을 입력해 주세요.”, 비밀번호 input에 placeholder는 “영문, 숫자를 조합해 8자 이상 입력해 주세요. ”비밀번호 확인 input에 placeholder는 “비밀번호와 일치하는 값을 입력해 주세요.”가 보이나요?
- [x] [기본] 이메일 input에서 focus out 할 때, 값이 없을 경우 “이메일을 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 “올바른 이메일 주소가 아닙니다.” 에러 메세지가 보이나요?
- [x] [기본] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 에러 메세지가 보이나요?
- [x] [기본] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input 아래에 “비밀번호가 일치하지 않아요.” 에러 메세지가 보이나요?
- [x] [기본] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 에러 메세지가 보이나요?
- [x] [기본] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 실행 되나요?
- [x] [기본] 이메일 중복 확인은 “/api/check-email” POST 요청해서 확인 할 수 있나요?
- [x] [기본] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?
- [x] [기본] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지나요?
- [x] [기본] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?

- [x] [기본] 소셜 로그인에 구글 아이콘 클릭시 ‘[https://www.google.com’](https://www.google.xn--com-to0a/), 카카오 아이콘 클릭시 ‘[https://www.kakaocorp.com/page’로](https://www.kakaocorp.com/page%E2%80%99%EB%A1%9C) 이동하나요?
- [x] [기본] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장하나요?
- [ ] [기본] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 ‘/folder’ 페이지로 이동하나요?

### 심화
- [ ] 로그인, 회원가입 기능에 react-hook-form을 활용했나요?

## 주요 변경사항

-
-

## 스크린샷

![image](이미지url)

## 멘토에게

- 로그인, 회원가입 요청부분 잘 구현 됐는지 모르겠습니다..
- 저번주 코드리뷰 주신 것과 멘토링 시간떄 알려주신 것 반영이 아직 안 됐습니다.. 차근차근 고쳐 보도록 하겠습니다
- 에러메세지가 뜬 상태에서 다시 입력하려고 focus하게 되면 파란색 테두리랑 빨간색 테두리가 겹치게 보이는데 어떻게 처리해줘야 할지 모르겠습니다
- 리액트 훅 폼 쓰는 것 나중에 적용시키려고 하니까 좀 많이 바꿔야돼서 이번주 과제에는 써보지 못 했습니다.
- next/link를 쓰면 사진처럼 에러가 나는데 괜찮은건가용.. 실행은 잘 되는 것 같아서 일단 그대로 뒀습니다
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/114053155/efc0adb2-7789-4435-a11a-078a80fd1f9f)

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
