### PR TITLE
[신민철] week16

### DIFF
--- a/pages/api/api.ts
+++ b/pages/api/api.ts
@@ -31,3 +31,30 @@ export const getSelectLinksInfo = async (folderId: number) => {
   const result = response.json();
   return result;
 };
+
+export const signInUser = async (email: string, password: string) => {
+  const userInfo = {
+    email: email,
+    password: password,
+  };
+
+  try {
+    const response = await fetch('https://bootcamp-api.codeit.kr/api/sign-in', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(userInfo),
+    });
+
+    if (response.status === 200) {
+      const result = await response.json();
+      localStorage.setItem('accessToken', result.data.accessToken);
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/pages/signin.tsx
+++ b/pages/signin.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import styles from '@/styles/Signin.module.css';
-import { emailRegex, passwordRegex } from '@/components/Regex';
-import logo from '@/public/logo.svg';
-import kakao from '@/public/kakao logo.svg';
-import google from '@/public/google.svg';
-import passwordOff from '@/public/passwordOff.svg';
-import passwordOn from '@/public/passwordOn.svg';
+import styles from '@styles/Signin.module.css';
+import { emailRegex, passwordRegex } from '@components/Regex';
+import logo from '@public/logo.svg';
+import kakao from '@public/kakao logo.svg';
+import google from '@public/google.svg';
+import passwordOff from '@public/passwordOff.svg';
+import passwordOn from '@public/passwordOn.svg';
+import { signInUser } from './api/api';
 
 export default function Signin() {
   const [email, setEmail] = useState('');
@@ -59,27 +60,17 @@ export default function Signin() {
   const handleSubmit = async (e: React.ChangeEvent<HTMLButtonElement>) => {
     e.preventDefault();
 
-    const userInfo = {
-      email: email,
-      password: password,
-    };
+    try {
+      const signIn = await signInUser(email, password);
 
-    const response = await fetch('https://bootcamp-api.codeit.kr/api/sign-in', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(userInfo),
-    });
-
-    if (response.status === 200) {
-      const result = await response.json();
-      localStorage.setItem('accessToken', result.data.accessToken);
-      window.location.assign('folder.html');
-      return;
-    } else {
-      setEmailError('이메일을 확인해 주세요.');
-      setPasswordError('비밀번호를 확인해 주세요.');
+      if (signIn) {
+        window.location.assign('folder.html');
+      } else {
+        setEmailError('이메일을 확인해 주세요.');
+        setPasswordError('비밀번호를 확인해 주세요.');
+      }
+    } catch (error) {
+      console.log(error);
     }
   };
 

--- a/pages/signup.tsx
+++ b/pages/signup.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import Link from 'next/link';
-import styles from '@/styles/Signup.module.css';
-import logo from '@/public/logo.svg';
-import kakao from '@/public/kakao logo.svg';
-import google from '@/public/google.svg';
-import passwordOff from '@/public/passwordOff.svg';
-import passwordOn from '@/public/passwordOn.svg';
-import { emailRegex, passwordRegex } from '@/components/Regex';
+import styles from '@styles/Signup.module.css';
+import logo from '@public/logo.svg';
+import kakao from '@public/kakao logo.svg';
+import google from '@public/google.svg';
+import passwordOff from '@public/passwordOff.svg';
+import passwordOn from '@public/passwordOn.svg';
+import { emailRegex, passwordRegex } from '@components/Regex';
 
 export default function Signup() {
   const [email, setEmail] = useState('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,10 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./*"]
+      "@*": ["./*"],
+      "@components": ["./*/components"],
+      "@public": ["./*/public"],
+      "@styles": ["./*/styles"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
## 요구사항

### 기본

- [ ] 링크 공유 페이지의 url path를 ‘/shared’에서 ‘/shared/{folderId}’로 변경해 주세요.

- [ ] 폴더의 정보는 ‘/api/folders/{folderId}’, 폴더 소유자의 정보는 ‘/api/users/{userId}’를 활용해 주세요.

- [ ] 링크 공유 페이지에서 폴더의 링크 데이터는 ‘/api/users/{userId}/links?folderId={folderId}’를 사용해 주세요.

- [ ] 폴더 페이지에서 유저가 access token이 없는 경우 ‘/signin’페이지로 이동하게 해주세요.

- [ ] 테스트 유저는 id: “[codeit@codeit.com](mailto:codeit@codeit.com)”, pw: “sprint101” 를 활용해 보세요.

- [ ] 폴더 페이지의 url path가 ‘/folder’일 경우 폴더 목록에서 “전체” 가 선택되어 있고, ‘/folder/{folderId}’일 경우 폴더 목록에서 {folderId} 에 해당하는 폴더가 선택되어 있고 폴더에 있는 링크들을 볼 수 있게 해주세요.

- [ ] 폴더 페이지에서 현재 유저의 폴더 목록 데이터를 받아올 때 ‘/api/folders’를 활용해 주세요.

- [ ] 폴더 페이지에서 전체 링크 데이터를 받아올 때 ‘/api/links’, 특정 폴더의 링크를 받아올 때 ‘/api/links?folderId={folderId}’를 활용해 주세요.

- [ ] 유효한 access token이 있는 경우 ‘/api/users’로 현재 로그인한 유저 정보를 받아 상단 네비게이션 유저 프로필을 보이게 해주세요.

### 심화

- [ ] 리퀘스트 헤더에 인증 토큰을 첨부할 때 axios interceptors 또는 이와 유사한 기능을 활용해 주세요.

## 주요 변경사항

-

## 스크린샷

![image](이미지url)

## 멘토에게

-
-
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
