### PR TITLE
[이서인] Week20

### DIFF
--- a/src/components/seoin/Form.tsx
+++ b/src/components/seoin/Form.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import InputSeoin from "./Input";
+import styles from "./FormSeoin.module.css";
+
+export default function FormSeoin() {
+  const [isError, setIsError] = useState(false);
+  return (
+    <form>
+      <InputSeoin
+        id="seoin"
+        type="text"
+        label="ID: "
+        style={styles.Medium}
+        isError={true}
+        errorText="아이디를 확인해주세요"
+        labelStyle={styles.Label}
+        placeholder={"아이디를 입력해주세요"}
+      />
+      <button type="submit" disabled={isError}>
+        제출
+      </button>
+    </form>
+  );
+}
+
+/*input 공용 컴포넌트 기능 명세
+type을 지정할 수 있다.
+label을 선택적으로 지정할 수 있다.
+FormSeoin.module.css를 활용해 스타일을 지정할 수 있다.
+isError로 error 시 input의 테두리를 빨갛게 만들 수 있다.
+labelStyle을 지정할 수 있다.
+placeholder를 지정할 수 있다.
+errorText를 넣거나 넣지 않을 수 있다.
+*/

--- a/src/components/seoin/FormSeoin.module.css
+++ b/src/components/seoin/FormSeoin.module.css
@@ -1,0 +1,19 @@
+.Small {
+}
+
+.Medium {
+}
+
+.Large {
+}
+
+.Label {
+}
+
+.Error {
+  border: 1px red solid;
+}
+
+.ErrorText {
+  color: red;
+}

--- a/src/components/seoin/HookForm.tsx
+++ b/src/components/seoin/HookForm.tsx
@@ -1,0 +1,68 @@
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import InputSeoin from "./Input";
+import styles from "./FormSeoin.module.css";
+
+type FormValues = {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+const schema = z
+  .object({
+    email: z
+      .string()
+      .trim()
+      .min(1, { message: "이메일을 입력해 주세요." })
+      .email({ message: "이메일 형식으로 입력해 주세요." }),
+    password: z
+      .string()
+      .trim()
+      .min(1, { message: "비밀번호를 입력해 주세요." })
+      .min(8, { message: "8자 이상 입력해 주세요." }),
+    passwordConfirm: z
+      .string()
+      .trim()
+      .min(1, { message: "비밀번호를 입력해 주세요." }),
+  })
+  .refine((data) => data.password === data.passwordConfirm, {
+    path: ["passwordConfirm"],
+    message: "비밀번호가 일치하지 않습니다.",
+  });
+
+export default function HookFormSeoin() {
+  const {
+    register,
+    formState: { errors, isValid, isSubmitting },
+    handleSubmit,
+    setError,
+    reset,
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    mode: "all",
+    defaultValues: {
+      email: "",
+      password: "",
+    },
+  });
+  const handleValidSubmit = (data: FormValues) => {
+    console.log(data);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleValidSubmit)}>
+      <InputSeoin
+        id="seoin"
+        type="text"
+        label="ID: "
+        style={styles.Medium}
+        isError={false}
+        labelStyle={styles.Label}
+        placeholder={"아이디를 입력해주세요"}
+      />
+    </form>
+  );
+}

--- a/src/components/seoin/Input.tsx
+++ b/src/components/seoin/Input.tsx
@@ -1,0 +1,41 @@
+import styles from "./FormSeoin.module.css";
+
+interface InputProps {
+  id: string;
+  type: string;
+  label?: string;
+  value?: string | number;
+  style?: string;
+  isError: boolean;
+  errorText?: string;
+  labelStyle?: string;
+  placeholder: string;
+}
+
+export default function InputSeoin({
+  id,
+  type,
+  label,
+  value,
+  style,
+  isError,
+  errorText,
+  labelStyle,
+  placeholder,
+}: InputProps) {
+  return (
+    <div>
+      <label htmlFor={id} className={labelStyle}>
+        {label}
+      </label>
+      <input
+        id={id}
+        type={type}
+        value={value}
+        className={`${style} ${isError && styles["Error"]}`}
+        placeholder={placeholder}
+      />
+      {isError && <p className={styles.ErrorText}>{errorText}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Input 요구사항

- [x]  라벨이 있을 수 있고 없을 수도 있다.
- [x]  라벨의 스타일을 사용처에서 커스텀 할 수 있어야 한다.
- [x]  에러 메시지가 없더라도 input의 빨간 테두리는 표시하고 싶다.
- [x]  에러 메세지의 스타일을 사용처에서 커스텀 할 수 있어야 한다.
- [x]  input의 사이즈, font-size, color 등 사용처에서 커스텀 할 수 있어야 한다.
- [ ]  react-hook-form을 사용하거나 사용하지 않을 수 있어야 한다.

## 주요 변경사항

- input 공용 컴포넌트 구현했습니다.
- 아직 유효성 검사 등을 적용하기 전입니다.

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/144193370/1ea2eaf9-5802-4c21-a420-b91ef4eb9b48)
![image](https://github.com/codeit-bootcamp-frontend/4-Weekly-Mission/assets/144193370/720f5c98-9e73-4926-a90b-feab1d080da3)

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
